### PR TITLE
feat: add double-hashes token style support

### DIFF
--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -6,7 +6,7 @@ function Expand-TemplateFile
 
     .DESCRIPTION
         Expands template files by replacing tokens with values from environment variables.
-        Supports multiple token styles: mustache ({{VAR}}), double-hashes (##VAR##), envsubst (${VAR}), and make ($(VAR)).
+        Supports multiple token styles: mustache/handlebars ({{VAR}}), double-hashes (##VAR##), envsubst (${VAR}), and make ($(VAR)).
 
     .PARAMETER Path
         Specify the path(s) to process. Can be files or directories.

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -6,13 +6,13 @@ function Expand-TemplateFile
 
     .DESCRIPTION
         Expands template files by replacing tokens with values from environment variables.
-        Supports multiple token styles: mustache ({{VAR}}), envsubst (${VAR}), and make ($(VAR)).
+        Supports multiple token styles: mustache ({{VAR}}), double-hashes (##VAR##), envsubst (${VAR}), and make ($(VAR)).
 
     .PARAMETER Path
         Specify the path(s) to process. Can be files or directories.
 
     .PARAMETER Style
-        Specify the token style to use. Valid values: mustache, handlebars, envsubst, make.
+        Specify the token style to use. Valid values: mustache, handlebars, double-hashes, envsubst, make.
         Default: mustache
 
     .PARAMETER Filter
@@ -71,7 +71,7 @@ function Expand-TemplateFile
         $Path,
 
         [Parameter(HelpMessage = 'Specify the token style to use')]
-        [ValidateSet('mustache', 'handlebars', 'envsubst', 'make', IgnoreCase = $true)]
+        [ValidateSet('mustache', 'handlebars', 'double-hashes', 'envsubst', 'make', IgnoreCase = $true)]
         [string]
         $Style = 'mustache',
 
@@ -120,6 +120,7 @@ function Expand-TemplateFile
 
         # Define token patterns with validation for environment variable names
         $mustachePattern = '\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}' # handlebars/mustache pattern, e.g. {{VARIABLE}}
+        $doubleHashesPattern = '##\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*##' # double-hashes pattern, e.g. ##VARIABLE##
         $envsubstPattern = '\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}' # envsubst template pattern, e.g. ${VARIABLE}
         $makePattern = '\$\(([a-zA-Z_][a-zA-Z0-9_]*)\)' # make pattern, e.g. $(VARIABLE)
 
@@ -128,6 +129,7 @@ function Expand-TemplateFile
         {
             'mustache' { $mustachePattern }
             'handlebars' { $mustachePattern }
+            'double-hashes' { $doubleHashesPattern }
             'envsubst' { $envsubstPattern }
             'make' { $makePattern }
             default { throw "Unknown token style: $Style" }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   - [Replace tokens in path](#replace-tokens-in-path)
   - [Using a path filter](#using-a-path-filter)
   - [Search multiple paths](#search-multiple-paths)
-  - [Replace envsubst and make styled tokens](#replace-envsubst-and-make-styled-tokens)
+  - [Replace envsubst, double-hashes, and make styled tokens](#replace-envsubst-double-hashes-and-make-styled-tokens)
   - [Search paths recursively](#search-paths-recursively)
   - [Replace an API key and URL in .env files](#replace-an-api-key-and-url-in-env-files)
   - [Exclude items and patterns](#exclude-items-and-patterns)
@@ -96,7 +96,7 @@ steps:
       NAME: jon
 ```
 
-### Replace envsubst and make styled tokens
+### Replace envsubst, double-hashes, and make styled tokens
 
 Replace tokens using the **envsubst** style/format, e.g. `${VARIABLE}`.
 
@@ -108,6 +108,20 @@ steps:
       paths: ./path/to/search
       filter: '*.json'
       style: envsubst
+    env:
+      NAME: jon
+```
+
+Replace tokens using the **double-hashes** style/format, e.g. `##VARIABLE##`.
+
+```yaml
+steps:
+  - name: Replace double-hashes styled tokens
+    uses: jonlabelle/replace-tokens-action@v1
+    with:
+      paths: ./path/to/search
+      filter: '*.json'
+      style: double-hashes
     env:
       NAME: jon
 ```
@@ -260,6 +274,7 @@ Tokens must be in one of following formats to be replaced:
 | name                 | style            | examples                   |
 | -------------------- | ---------------- | -------------------------- |
 | `mustache` (default) | `{{ VARIABLE }}` | `{{TOKEN}}`, `{{ TOKEN }}` |
+| `double-hashes`      | `## VARIABLE ##` | `##TOKEN##`, `## TOKEN ##` |
 | `envsubst`           | `${VARIABLE}`    | `${TOKEN}`                 |
 | `make`               | `$(VARIABLE)`    | `$(TOKEN)`                 |
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Replace tokens using the **make** style/format, e.g. `$(VARIABLE)`.
 
 ```yaml
 steps:
-  - name: Replace envsubst styled tokens
+  - name: Replace make styled tokens
     uses: jonlabelle/replace-tokens-action@v1
     with:
       paths: ./path/to/search

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Expand-TemplateFile Function' {
         # Store list of test environment variables for cleanup
         $script:testEnvVars = @(
             'NAME', 'ID', 'VALID_NAME', '_TEST_VAR', 'SPECIAL',
-            'ENV_VAR', '123VAR', 'MAKE_VAR', 'MAKE', 'MAKE-VAR',
+            'ENV_VAR', '123VAR', 'HASH_VAR', 'MAKE_VAR', 'MAKE', 'MAKE-VAR',
             'VAR', 'VAR2', 'VAR3', 'USER', 'HOSTNAME', 'TESTVAR',
             '1INVALID'
         )
@@ -133,6 +133,21 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $result | Should -Be 'Hello, Bob!'
+    }
+
+    It 'Replaces tokens with double-hashes style' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'double-hashes-style-basic.txt'
+        Set-Utf8Content -Path $testFile -Value 'Hello, ##NAME##!' -NoNewline
+
+        $env:NAME = 'Bailey'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'double-hashes' -Encoding 'utf8NoBOM' -NoNewline
+        $result = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $result | Should -Be 'Hello, Bailey!'
     }
 
     It 'Replaces tokens with make style' {
@@ -237,6 +252,22 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $result | Should -Be 'Valid: EnvValue - Invalid: ${123VAR}'
+    }
+
+    It 'Correctly handles double-hashes style with valid/invalid variable names' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'double-hashes-style.txt'
+        Set-Utf8Content -Path $testFile -Value 'Valid: ## HASH_VAR ## - Invalid: ##123VAR##' -NoNewline
+
+        $env:HASH_VAR = 'HashValue'
+        $env:123VAR = 'Invalid'  # Won't be used as it's an invalid env var name
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'double-hashes' -Encoding 'utf8NoBOM' -NoNewline
+        $result = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $result | Should -Be 'Valid: HashValue - Invalid: ##123VAR##'
     }
 
     It 'Correctly handles make style with valid/invalid variable names' {
@@ -470,4 +501,3 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Test Zero'
     }
 }
-

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -260,7 +260,7 @@ Describe 'Expand-TemplateFile Function' {
         Set-Utf8Content -Path $testFile -Value 'Valid: ## HASH_VAR ## - Invalid: ##123VAR##' -NoNewline
 
         $env:HASH_VAR = 'HashValue'
-        $env:123VAR = 'Invalid'  # Won't be used as it's an invalid env var name
+        $env:123VAR = 'Invalid'  # Won't be matched - token variable names must start with a letter or underscore
 
         # Act
         Expand-TemplateFile -Path $testFile -Style 'double-hashes' -Encoding 'utf8NoBOM' -NoNewline

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   style:
     description: >-
       The style (or format) of the tokens that will be replaced.
-      Accepted values are `mustache/handlebars` (ex: `{{ VARIABLE }}`), `envsubst` (ex: `${VARIABLE}`), and `make` (ex: `$(VARIABLE)`).
+      Accepted values are `mustache/handlebars` (ex: `{{ VARIABLE }}`), `double-hashes` (ex: `## VARIABLE ##`), `envsubst` (ex: `${VARIABLE}`), and `make` (ex: `$(VARIABLE)`).
       The default token style is `mustache`.
     required: false
     default: 'mustache'


### PR DESCRIPTION
This PR adds a new `double-hashes` token style for tokens like `##TOKEN##` and `## TOKEN ##`.