### PR TITLE
fix: several behavior and documentation gaps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        style: [mustache, envsubst, make]
+        style: [mustache, handlebars, brackets, double-hashes, envsubst, make]
         os: [ubuntu-latest, windows-latest, macos-latest]
         shell: [pwsh]
         include:
           # Add PowerShell 5.1 tests on Windows for each style
           - os: windows-latest
             style: mustache
+            shell: powershell
+          - os: windows-latest
+            style: handlebars
+            shell: powershell
+          - os: windows-latest
+            style: brackets
+            shell: powershell
+          - os: windows-latest
+            style: double-hashes
             shell: powershell
           - os: windows-latest
             style: envsubst
@@ -122,3 +131,76 @@ jobs:
 
       - name: Run Pester Tests
         run: Invoke-Pester -Path ./Tests/Expand-TemplateFile.Tests.ps1 -Output Detailed
+
+  dry-run:
+    name: Dry run fail check on ${{ matrix.os }} (${{ matrix.shell }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        shell: [pwsh]
+        include:
+          - os: windows-latest
+            shell: powershell
+    steps:
+      - name: Checkout repository for dry-run test on ${{ matrix.os }}
+        uses: actions/checkout@main
+
+      - name: Setup dry-run subject on ${{ matrix.os }}
+        id: dry-run-setup
+        run: |
+          $subject = Join-Path -Path (Join-Path -Path $pwd -ChildPath Tests) -ChildPath dry-run-subject.tpl
+          $pristine = Join-Path -Path (Join-Path -Path (Join-Path -Path (Join-Path -Path $pwd -ChildPath Tests) -ChildPath stubs) -ChildPath pristine) -ChildPath mustache.tpl
+          $originalHash = (Get-FileHash -Path $pristine -Algorithm SHA256).Hash
+
+          Copy-Item -Path $pristine -Destination $subject -Force
+
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "subject-path=$subject" -Encoding UTF8
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "original-hash=$originalHash" -Encoding UTF8
+
+      - name: Perform dry-run action on ${{ matrix.os }}
+        id: dry-run-action
+        uses: ./
+        with:
+          paths: ${{ steps.dry-run-setup.outputs.subject-path }}
+          style: mustache
+          dry-run: true
+          fail: true
+          no-newline: true
+        env:
+          NAME: jon
+
+      - name: Assert dry-run file is unchanged on ${{ matrix.os }}
+        run: |
+          $expected = "${{ steps.dry-run-setup.outputs.original-hash }}"
+          $actual = (Get-FileHash -Path "${{ steps.dry-run-setup.outputs.subject-path }}" -Algorithm SHA256).Hash
+
+          if ($expected -ne $actual) {
+            Write-Host '::error title=FAIL Dry-run mutated the file::Dry-run should not write any file changes.'
+            exit 1
+          } else {
+            Write-Host 'PASS: Dry-run left the file unchanged'
+          }
+
+      - name: Assert dry-run outputs on ${{ matrix.os }}
+        run: |
+          if ('${{ steps.dry-run-action.outputs.modified-files-count }}' -ne '0') {
+            Write-Host '::error title=FAIL Dry-run modified count mismatch::Expected modified-files-count to be 0.'
+            exit 1
+          }
+
+          if ('${{ steps.dry-run-action.outputs.would-modify-files-count }}' -ne '1') {
+            Write-Host '::error title=FAIL Dry-run candidate count mismatch::Expected would-modify-files-count to be 1.'
+            exit 1
+          }
+
+          if ('${{ steps.dry-run-action.outputs.tokens-replaced }}' -ne '5') {
+            Write-Host '::error title=FAIL Dry-run replacement count mismatch::Expected tokens-replaced to be 5.'
+            exit 1
+          }
+
+          Write-Host 'PASS: Dry-run outputs are correct'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     "bigendianutf",
     "commitlint",
     "envsubst",
-    "jonlabelle"
+    "jonlabelle",
+    "nonwindows"
   ]
 }

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -107,6 +107,16 @@ function Expand-TemplateFile
 
     begin
     {
+        function Test-IsWindows
+        {
+            if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)
+            {
+                return [bool]$IsWindows
+            }
+
+            return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+        }
+
         # Validate that -Depth is only used with -Recurse
         if ($Depth -gt 0 -and -not $Recurse)
         {
@@ -142,7 +152,16 @@ function Expand-TemplateFile
 
         # Cache environment variables for better performance
         # Avoid repeated Test-Path and Get-Item calls
-        $EnvVars = @{}
+        $envComparer = if (Test-IsWindows)
+        {
+            [System.StringComparer]::OrdinalIgnoreCase
+        }
+        else
+        {
+            [System.StringComparer]::Ordinal
+        }
+
+        $EnvVars = New-Object 'System.Collections.Generic.Dictionary[string,string]' $envComparer
         Get-ChildItem Env: | ForEach-Object { $EnvVars[$_.Name] = $_.Value }
 
         # Helper function to normalize encoding settings
@@ -199,7 +218,7 @@ function Expand-TemplateFile
         $encodingConfig = Get-NormalizedEncoding -EncodingName $Encoding
 
         # Function to replace tokens in a file
-        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [hashtable] $EnvironmentVars, [PSCustomObject] $EncodingConfig, [bool] $NoNewline)
+        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string,string]] $EnvironmentVars, [PSCustomObject] $EncodingConfig, [bool] $NoNewline)
         {
             # Use script-scoped variables for per-file counters so they work inside scriptblocks
             $script:tokensInFile = 0
@@ -239,8 +258,11 @@ function Expand-TemplateFile
                     })
 
                 $modified = $false
+                $wouldModify = $false
                 if ($content -ne $originalContent)
                 {
+                    $wouldModify = $true
+
                     # Use ShouldProcess for -WhatIf support
                     if ($PSCmdlet.ShouldProcess($File, 'Replace tokens'))
                     {
@@ -285,6 +307,7 @@ function Expand-TemplateFile
                     FilePath = $File
                     TokensReplaced = $script:tokensInFile
                     TokensSkipped = $script:skippedInFile
+                    WouldModify = $wouldModify
                     Modified = $modified
                 }
 
@@ -327,11 +350,12 @@ function Expand-TemplateFile
     {
         # Count modified files
         $modifiedCount = ($script:fileResults | Where-Object { $_.Modified }).Count
+        $wouldModifyCount = ($script:fileResults | Where-Object { $_.WouldModify }).Count
 
         # Output summary
         if ($WhatIfPreference)
         {
-            $message = "What if: Would replace $($script:tokensReplaced) token(s) in $modifiedCount file(s)"
+            $message = "What if: Would replace $($script:tokensReplaced) token(s) in $wouldModifyCount file(s)"
             Write-Information $message -InformationAction Continue
         }
         else

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -1,4 +1,94 @@
 [CmdletBinding()]
+<#
+    .SYNOPSIS
+        Invokes the replace-tokens action runner.
+
+    .DESCRIPTION
+        Parses composite action string inputs, dot-sources Expand-TemplateFile.ps1,
+        executes token replacement, writes a human-readable summary, and emits
+        GitHub Actions step outputs through GITHUB_OUTPUT when available.
+
+        This script is intended to be used by the composite action entrypoint on
+        Windows PowerShell 5.1 and PowerShell Core 6+.
+
+    .PARAMETER PathsInput
+        A multiline string containing one or more file or directory paths to
+        process. Empty input defaults to the current directory (.).
+
+    .PARAMETER Style
+        The token style to replace. Valid values are mustache, handlebars,
+        brackets, double-hashes, envsubst, and make.
+
+    .PARAMETER Filter
+        An optional Get-ChildItem filter used to limit matching files.
+
+    .PARAMETER ExcludeInput
+        A multiline string containing one or more file or directory patterns to
+        exclude from processing.
+
+    .PARAMETER Recurse
+        A string boolean value that controls recursive directory traversal.
+
+    .PARAMETER Depth
+        A string integer value that sets the recursion depth when Recurse is true.
+
+    .PARAMETER FollowSymlinks
+        A string boolean value that controls whether symbolic links are followed
+        while traversing directories.
+
+    .PARAMETER Encoding
+        The file encoding passed to Expand-TemplateFile.ps1 for read and write
+        operations.
+
+    .PARAMETER NoNewline
+        A string boolean value that controls whether a trailing newline is omitted
+        when files are written.
+
+    .PARAMETER DryRun
+        A string boolean value that enables WhatIf behavior. When true, the script
+        reports files that would change without writing them.
+
+    .PARAMETER Fail
+        A string boolean value that causes the script to exit with code 1 when no
+        files are changed, or when DryRun is true, when no files would change.
+
+    .PARAMETER VerboseInput
+        A string boolean value that enables verbose output from
+        Expand-TemplateFile.ps1.
+
+    .EXAMPLE
+        ./Invoke-ReplaceTokens.ps1
+
+        Runs the action helper with its defaults, processing the current directory
+        with mustache token style.
+
+    .EXAMPLE
+        ./Invoke-ReplaceTokens.ps1 -PathsInput './appsettings.template.json' -Style envsubst -DryRun true
+
+        Previews envsubst-style token replacement for a single file without writing
+        any changes.
+
+    .EXAMPLE
+        $paths = @'
+        ./config
+        ./deploy
+        '@
+        $exclude = @'
+        *.bak
+        *.example
+        '@
+        ./Invoke-ReplaceTokens.ps1 -PathsInput $paths -ExcludeInput $exclude -Filter '*.json' -Recurse true -Depth 2
+
+        Processes multiple paths recursively, limits matching files to *.json, and
+        excludes backup and example files.
+
+    .EXAMPLE
+        $env:GITHUB_OUTPUT = (Join-Path -Path $PWD -ChildPath 'action-output.txt')
+        ./Invoke-ReplaceTokens.ps1 -PathsInput './template.txt' -NoNewline true -Fail true
+
+        Runs the helper the same way the composite action does and writes action
+        outputs to the file referenced by GITHUB_OUTPUT.
+#>
 param(
     [string]
     $PathsInput = '.',
@@ -51,8 +141,8 @@ function Split-MultilineInput
 
     return @(
         $Value -split '\r?\n|\r' |
-            ForEach-Object { $_.Trim() } |
-            Where-Object { $_ -ne '' }
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne '' }
     )
 }
 
@@ -71,7 +161,7 @@ function Set-ActionOutput
         return
     }
 
-    Add-Content -Path $env:GITHUB_OUTPUT -Value ("{0}={1}" -f $Name, $Value) -Encoding UTF8
+    Add-Content -Path $env:GITHUB_OUTPUT -Value ('{0}={1}' -f $Name, $Value) -Encoding UTF8
 }
 
 $paths = Split-MultilineInput -Value $PathsInput
@@ -159,7 +249,7 @@ if ($reportedFiles.Count -eq 0)
 else
 {
     $reportedFiles | ForEach-Object {
-        Write-Output -InputObject ("  {0} - Replaced: {1}, Skipped: {2}" -f $_.FilePath, $_.TokensReplaced, $_.TokensSkipped)
+        Write-Output -InputObject ('  {0} - Replaced: {1}, Skipped: {2}' -f $_.FilePath, $_.TokensReplaced, $_.TokensSkipped)
     }
 }
 

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -1,0 +1,169 @@
+[CmdletBinding()]
+param(
+    [string]
+    $PathsInput = '.',
+
+    [string]
+    $Style = 'mustache',
+
+    [string]
+    $Filter,
+
+    [string]
+    $ExcludeInput,
+
+    [string]
+    $Recurse = 'false',
+
+    [string]
+    $Depth = '0',
+
+    [string]
+    $FollowSymlinks = 'false',
+
+    [string]
+    $Encoding = 'utf8',
+
+    [string]
+    $NoNewline = 'false',
+
+    [string]
+    $DryRun = 'false',
+
+    [string]
+    $Fail = 'false',
+
+    [string]
+    $VerboseInput = 'false'
+)
+
+function Split-MultilineInput
+{
+    param(
+        [string]
+        $Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value))
+    {
+        return @()
+    }
+
+    return @(
+        $Value -split '\r?\n|\r' |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -ne '' }
+    )
+}
+
+function Set-ActionOutput
+{
+    param(
+        [string]
+        $Name,
+
+        [string]
+        $Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT))
+    {
+        return
+    }
+
+    Add-Content -Path $env:GITHUB_OUTPUT -Value ("{0}={1}" -f $Name, $Value) -Encoding UTF8
+}
+
+$paths = Split-MultilineInput -Value $PathsInput
+if ($paths.Count -eq 0)
+{
+    $paths = @('.')
+}
+
+$exclude = Split-MultilineInput -Value $ExcludeInput
+$dryRunEnabled = [System.Convert]::ToBoolean($DryRun)
+$failEnabled = [System.Convert]::ToBoolean($Fail)
+
+$params = @{
+    Path = $paths
+    Style = $Style
+    Recurse = [System.Convert]::ToBoolean($Recurse)
+    Depth = [System.Convert]::ToInt32($Depth)
+    FollowSymlinks = [System.Convert]::ToBoolean($FollowSymlinks)
+    Encoding = $Encoding
+    NoNewline = [System.Convert]::ToBoolean($NoNewline)
+    Verbose = [System.Convert]::ToBoolean($VerboseInput)
+}
+
+if (-not [string]::IsNullOrWhiteSpace($Filter))
+{
+    $params.Filter = $Filter
+}
+
+if ($exclude.Count -gt 0)
+{
+    $params.Exclude = $exclude
+}
+
+if ($dryRunEnabled)
+{
+    $params.WhatIf = $true
+}
+
+$functionPath = Join-Path -Path $PSScriptRoot -ChildPath 'Expand-TemplateFile.ps1'
+. $functionPath
+
+$result = @(Expand-TemplateFile @params)
+if ($? -eq $false)
+{
+    Write-Output '::error title=Failed::Review console output for errors'
+    exit 1
+}
+
+$modifiedFiles = @($result | Where-Object { $_.Modified })
+$wouldModifyFiles = @($result | Where-Object { $_.WouldModify })
+$reportedFiles = if ($dryRunEnabled) { $wouldModifyFiles } else { $modifiedFiles }
+
+$totalTokensReplaced = ($result | Measure-Object -Property TokensReplaced -Sum).Sum
+if ($null -eq $totalTokensReplaced)
+{
+    $totalTokensReplaced = 0
+}
+
+$totalTokensSkipped = ($result | Measure-Object -Property TokensSkipped -Sum).Sum
+if ($null -eq $totalTokensSkipped)
+{
+    $totalTokensSkipped = 0
+}
+
+if ($failEnabled -and $reportedFiles.Count -eq 0)
+{
+    Write-Output '::error title=No operation performed::Ensure your token file paths are correct, and you have defined the appropriate tokens to replace.'
+    exit 1
+}
+
+$summaryPrefix = if ($dryRunEnabled)
+{
+    'Tokens would be replaced in the following file(s):'
+}
+else
+{
+    'Tokens were replaced in the following file(s):'
+}
+
+Write-Output -InputObject $summaryPrefix
+if ($reportedFiles.Count -eq 0)
+{
+    Write-Output -InputObject '  None'
+}
+else
+{
+    $reportedFiles | ForEach-Object {
+        Write-Output -InputObject ("  {0} - Replaced: {1}, Skipped: {2}" -f $_.FilePath, $_.TokensReplaced, $_.TokensSkipped)
+    }
+}
+
+Set-ActionOutput -Name 'tokens-replaced' -Value $totalTokensReplaced
+Set-ActionOutput -Name 'tokens-skipped' -Value $totalTokensSkipped
+Set-ActionOutput -Name 'modified-files-count' -Value $modifiedFiles.Count
+Set-ActionOutput -Name 'would-modify-files-count' -Value $wouldModifyFiles.Count

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 ## Table of contents
 
 - [Usage](#usage)
+- [Outputs](#outputs)
+- [Platform support](#platform-support)
 - [Examples](#examples)
   - [Replace tokens in path](#replace-tokens-in-path)
   - [Using a path filter](#using-a-path-filter)
   - [Search multiple paths](#search-multiple-paths)
-  - [Replace envsubst, brackets, double-hashes, and make styled tokens](#replace-envsubst-brackets-double-hashes-and-make-styled-tokens)
+  - [Replace handlebars, envsubst, brackets, double-hashes, and make styled tokens](#replace-handlebars-envsubst-brackets-double-hashes-and-make-styled-tokens)
   - [Search paths recursively](#search-paths-recursively)
   - [Replace an API key and URL in .env files](#replace-an-api-key-and-url-in-env-files)
   - [Exclude items and patterns](#exclude-items-and-patterns)
@@ -30,7 +32,7 @@ See [action.yml](action.yml)
 
 | name              | description                        | type    | required | default    | example       |
 | ----------------- | ---------------------------------- | ------- | -------- | ---------- | ------------- |
-| `paths`           | Token file paths [^1]              | string  | true     | none       | `./prod.json` |
+| `paths`           | Token file paths [^1]              | string  | false    | `.`        | `./prod.json` |
 | `style`           | [Token style/format](#token-style) | string  | false    | `mustache` | `envsubst`    |
 | `filter`          | Filter pattern [^2]                | string  | false    | none       | `*.json`      |
 | `exclude`         | Exclusion patterns [^3]            | string  | false    | none       | `*dev*.json`  |
@@ -38,10 +40,24 @@ See [action.yml](action.yml)
 | `depth`           | Depth of recursion                 | number  | false    | none       | `2`           |
 | `follow-symlinks` | Follow symbolic links              | boolean | false    | `false`    | `false`       |
 | `dry-run`         | Preview without modifying          | boolean | false    | `false`    | `true`        |
-| `fail`            | Fail if no tokens replaced         | boolean | false    | `false`    | `false`       |
+| `fail`            | Fail if no files change [^4]       | boolean | false    | `false`    | `false`       |
 | `encoding`        | [File encoding](#file-encoding)    | string  | false    | `utf8`     | `unicode`     |
 | `no-newline`      | No newline at end-of-file          | boolean | false    | `false`    | `true`        |
 | `verbose`         | Enable verbose output              | boolean | false    | `false`    | `true`        |
+
+## Outputs
+
+- `tokens-replaced`: Total number of tokens replaced, or that would be replaced in dry-run mode.
+- `tokens-skipped`: Total number of tokens skipped because no matching value was available.
+- `modified-files-count`: Number of files updated by the action.
+- `would-modify-files-count`: Number of files that would be updated in dry-run mode.
+
+## Platform support
+
+- Windows runners execute the composite action with Windows PowerShell 5.1.
+- Linux and macOS runners execute the composite action with PowerShell Core (`pwsh`).
+- Environment variable name matching follows platform conventions: case-insensitive on Windows, case-sensitive on Linux and macOS.
+- The `Expand-TemplateFile.ps1` script remains compatible with Windows PowerShell 5.1 and PowerShell Core 6+.
 
 ## Examples
 
@@ -61,7 +77,7 @@ steps:
 ```
 
 > [!NOTE]  
-> To avoid issues, it's good practice to treat environment variables as case sensitive, irrespective of the behavior of the operating system and shell you are using.
+> Environment variable names are matched case-insensitively on Windows, and case-sensitively on Linux and macOS.
 
 ### Using a path filter
 
@@ -96,7 +112,21 @@ steps:
       NAME: jon
 ```
 
-### Replace envsubst, brackets, double-hashes, and make styled tokens
+### Replace handlebars, envsubst, brackets, double-hashes, and make styled tokens
+
+Replace tokens using the **handlebars** style/format, e.g. `{{VARIABLE}}`.
+
+```yaml
+steps:
+  - name: Replace handlebars styled tokens
+    uses: jonlabelle/replace-tokens-action@v1
+    with:
+      paths: ./path/to/search
+      filter: '*.json'
+      style: handlebars
+    env:
+      NAME: jon
+```
 
 Replace tokens using the **envsubst** style/format, e.g. `${VARIABLE}`.
 
@@ -232,10 +262,12 @@ steps:
 
 > [!TIP]
 > Use `dry-run` to preview changes before applying them in production. This is especially useful when testing token configurations.
+> [!NOTE]
+> When `dry-run: true` and `fail: true` are used together, the action fails only if no files would be changed.
 
 ### Fail on no-op
 
-Fail the step if no tokens were replaced.
+Fail the step if no files were changed.
 
 ```yaml
 steps:
@@ -291,6 +323,7 @@ Tokens must be in one of following formats to be replaced:
 | name                 | style            | examples                   |
 | -------------------- | ---------------- | -------------------------- |
 | `mustache` (default) | `{{ VARIABLE }}` | `{{TOKEN}}`, `{{ TOKEN }}` |
+| `handlebars`         | `{{ VARIABLE }}` | `{{TOKEN}}`, `{{ TOKEN }}` |
 | `brackets`           | `< VARIABLE >`   | `<TOKEN>`, `< TOKEN >`     |
 | `double-hashes`      | `## VARIABLE ##` | `##TOKEN##`, `## TOKEN ##` |
 | `envsubst`           | `${VARIABLE}`    | `${TOKEN}`                 |
@@ -317,8 +350,10 @@ The default file encoding for read/write operations is set to `utf8`, _without_ 
 
 [MIT](LICENSE)
 
-[^1]: A path to one or more locations. Wildcards are accepted. The default location is the current directory (`.`). Specify multiple paths on separate lines using a multiline string `|`.
+[^1]: A path to one or more locations. Wildcards are accepted. If omitted, the action defaults to the current directory (`.`). Specify multiple paths on separate lines using a multiline string `|`.
 
 [^2]: `filter` only supports `*` and `?` wildcards.
 
 [^3]: One or more string items or patterns to be matched, and excluded from the results. Wildcard characters are accepted. Specify multiple exclusions on separate lines using a multiline string `|`. See Microsoft's [Get-ChildItem -Exclude](https://learn.microsoft.com/powershell/module/microsoft.powershell.management/get-childitem#-exclude) docs for more information.
+
+[^4]: When `dry-run` is enabled, `fail` checks whether any files would change instead of whether any files were written.

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -12,6 +12,16 @@ Describe 'Expand-TemplateFile Function' {
         # Import the function being tested
         . (Join-Path -Path (Get-Item -Path $PSScriptRoot).Parent.FullName -ChildPath 'Expand-TemplateFile.ps1')
 
+        function Test-IsWindows
+        {
+            if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)
+            {
+                return [bool]$IsWindows
+            }
+
+            return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+        }
+
         # Set up a temporary test directory
         $testDir = Join-Path -Path $PSScriptRoot -ChildPath 'TokenReplaceTest'
         New-Item -Path $testDir -ItemType Directory -Force | Out-Null
@@ -195,7 +205,7 @@ Describe 'Expand-TemplateFile Function' {
         $result | Should -Be 'Hello, {{NAME}}!' # Token remains unchanged
     }
 
-    It 'Fails the step if no tokens were replaced and fail is true' {
+    It 'Returns no modified files when no tokens are present' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'no-tokens.txt'
         Set-Utf8Content -Path $testFile -Value 'No tokens here!' -NoNewline
@@ -474,6 +484,9 @@ Describe 'Expand-TemplateFile Function' {
 
         # Result should still track what would have been changed
         $result | Should -Not -BeNullOrEmpty
+        $result[0].TokensReplaced | Should -Be 1
+        $result[0].WouldModify | Should -Be $true
+        $result[0].Modified | Should -Be $false
     }
 
     It 'WhatIf prevents file modification' {
@@ -489,6 +502,34 @@ Describe 'Expand-TemplateFile Function' {
         # Assert - File should not be modified
         $content = Get-Content -Path $testFile -Raw
         $content | Should -Be 'ShouldProcess {{TESTVAR}} test' -Because 'WhatIf should not modify files'
+        $result[0].WouldModify | Should -Be $true
+        $result[0].Modified | Should -Be $false
+    }
+
+    It 'Uses platform-appropriate case sensitivity for environment variable names' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'case-sensitive-env-var.txt'
+        Set-Utf8Content -Path $testFile -Value 'Case {{name}} test' -NoNewline
+
+        $env:NAME = 'CaseValue'
+
+        # Act
+        $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
+        $content = Get-Content -Path $testFile -Raw
+
+        # Assert
+        if (Test-IsWindows)
+        {
+            $content | Should -Be 'Case CaseValue test'
+            $result[0].TokensReplaced | Should -Be 1
+            $result[0].Modified | Should -Be $true
+        }
+        else
+        {
+            $content | Should -Be 'Case {{name}} test'
+            $result[0].TokensReplaced | Should -Be 0
+            $result[0].Modified | Should -Be $false
+        }
     }
 
     It 'Throws error when -Depth is used without -Recurse' {

--- a/Tests/stubs/pristine/brackets.tpl
+++ b/Tests/stubs/pristine/brackets.tpl
@@ -1,0 +1,5 @@
+< NAME >
+    <NAME>
+        <NAME>
+    <NAME>
+< NAME >

--- a/Tests/stubs/pristine/double-hashes.tpl
+++ b/Tests/stubs/pristine/double-hashes.tpl
@@ -1,0 +1,5 @@
+## NAME ##
+    ##NAME##
+        ##NAME##
+    ##NAME##
+## NAME ##

--- a/Tests/stubs/pristine/handlebars.tpl
+++ b/Tests/stubs/pristine/handlebars.tpl
@@ -1,0 +1,5 @@
+{{ NAME }}
+    {{NAME}}
+        {{NAME}}
+    {{NAME}}
+{{ NAME }}

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ inputs:
       Wildcards are accepted.
       The default location is the current directory (`.`).
       Example: `./path/to/my/settings.json`
-    required: true
+    required: false
+    default: '.'
 
   style:
     description: >-
@@ -85,7 +86,9 @@ inputs:
     default: 'false'
 
   fail:
-    description: Fail the step if no tokens were replaced.
+    description: >-
+      Fail the step if no files were changed.
+      When `dry-run` is enabled, fail the step if no files would be changed.
     required: false
     default: 'false'
 
@@ -96,52 +99,91 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  tokens-replaced:
+    description: Total number of tokens replaced or that would be replaced in dry-run mode.
+    value: ${{ steps.replace-tokens-windows.outputs.tokens-replaced || steps.replace-tokens-nonwindows.outputs.tokens-replaced }}
+  tokens-skipped:
+    description: Total number of tokens skipped because no matching value was available.
+    value: ${{ steps.replace-tokens-windows.outputs.tokens-skipped || steps.replace-tokens-nonwindows.outputs.tokens-skipped }}
+  modified-files-count:
+    description: Number of files updated by the action.
+    value: ${{ steps.replace-tokens-windows.outputs.modified-files-count || steps.replace-tokens-nonwindows.outputs.modified-files-count }}
+  would-modify-files-count:
+    description: Number of files that would be updated in dry-run mode.
+    value: ${{ steps.replace-tokens-windows.outputs.would-modify-files-count || steps.replace-tokens-nonwindows.outputs.would-modify-files-count }}
+
 runs:
   using: composite
   steps:
-    - name: Replace tokens
+    - id: replace-tokens-windows
+      name: Replace tokens (Windows PowerShell)
+      if: ${{ runner.os == 'Windows' }}
+      shell: powershell
+      run: |
+        $pathsInput = @'
+        ${{ inputs.paths }}
+        '@
+        $excludeInput = @'
+        ${{ inputs.exclude }}
+        '@
+        $filterInput = @'
+        ${{ inputs.filter }}
+        '@
+        $styleInput = @'
+        ${{ inputs.style }}
+        '@
+        $encodingInput = @'
+        ${{ inputs.encoding }}
+        '@
+
+        $scriptPath = Join-Path -Path '${{ github.action_path }}' -ChildPath 'Invoke-ReplaceTokens.ps1'
+        & $scriptPath `
+          -PathsInput $pathsInput `
+          -Style $styleInput `
+          -Filter $filterInput `
+          -ExcludeInput $excludeInput `
+          -Recurse '${{ inputs.recurse }}' `
+          -Depth '${{ inputs.depth }}' `
+          -FollowSymlinks '${{ inputs.follow-symlinks }}' `
+          -Encoding $encodingInput `
+          -NoNewline '${{ inputs.no-newline }}' `
+          -DryRun '${{ inputs.dry-run }}' `
+          -Fail '${{ inputs.fail }}' `
+          -VerboseInput '${{ inputs.verbose }}'
+
+    - id: replace-tokens-nonwindows
+      name: Replace tokens (PowerShell Core)
+      if: ${{ runner.os != 'Windows' }}
       shell: pwsh
       run: |
-        # Split multiline paths
-        $paths = '${{ inputs.paths }}' -split '\r?\n|\r' | Where-Object {$_.Trim() -ne ''}
-        $exclude = '${{ inputs.exclude }}' -split '\r?\n|\r' | Where-Object {$_.Trim() -ne ''}
+        $pathsInput = @'
+        ${{ inputs.paths }}
+        '@
+        $excludeInput = @'
+        ${{ inputs.exclude }}
+        '@
+        $filterInput = @'
+        ${{ inputs.filter }}
+        '@
+        $styleInput = @'
+        ${{ inputs.style }}
+        '@
+        $encodingInput = @'
+        ${{ inputs.encoding }}
+        '@
 
-        $params = @{
-          Path = $paths
-          Filter = '${{ inputs.filter }}'
-          Recurse = [System.Convert]::ToBoolean('${{ inputs.recurse }}')
-          Depth = [System.Convert]::ToInt32('${{ inputs.depth }}')
-          FollowSymlinks = [System.Convert]::ToBoolean('${{ inputs.follow-symlinks }}')
-          Style = '${{ inputs.style }}'
-          Encoding = '${{ inputs.encoding }}'
-          NoNewline = [System.Convert]::ToBoolean('${{ inputs.no-newline }}')
-          Exclude = $exclude
-          Verbose = [System.Convert]::ToBoolean('${{ inputs.verbose }}')
-        }
-
-        # Add WhatIf if dry-run is enabled
-        $dryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
-        if ($dryRun) {
-          $params.Add('WhatIf', $true)
-        }
-
-        # Import and call the function directly
-        $scriptPath = Join-Path -Path '${{ github.action_path }}' -ChildPath 'Expand-TemplateFile.ps1'
-        . $scriptPath
-        $result = Expand-TemplateFile @params
-        if ($? -eq $false) {
-          echo "::error title=✘ Failed::Review console output for errors"
-          exit 1
-        }
-
-        $fail = [System.Convert]::ToBoolean('${{ inputs.fail }}')
-        $modifiedFiles = $result | Where-Object { $_.Modified }
-        if (($fail -eq $true) -and ($modifiedFiles.Count -eq 0)) {
-          echo "::error title=✘ No operation performed::Ensure your token file paths are correct, and you have defined the appropriate tokens to replace."
-          exit 1
-        }
-
-        Write-Output -InputObject 'Tokens were replaced in the following file(s):'
-        $result | Where-Object { $_.Modified } | ForEach-Object {
-          Write-Output -InputObject "  $($_.FilePath) - Replaced: $($_.TokensReplaced), Skipped: $($_.TokensSkipped)"
-        }
+        $scriptPath = Join-Path -Path '${{ github.action_path }}' -ChildPath 'Invoke-ReplaceTokens.ps1'
+        & $scriptPath `
+          -PathsInput $pathsInput `
+          -Style $styleInput `
+          -Filter $filterInput `
+          -ExcludeInput $excludeInput `
+          -Recurse '${{ inputs.recurse }}' `
+          -Depth '${{ inputs.depth }}' `
+          -FollowSymlinks '${{ inputs.follow-symlinks }}' `
+          -Encoding $encodingInput `
+          -NoNewline '${{ inputs.no-newline }}' `
+          -DryRun '${{ inputs.dry-run }}' `
+          -Fail '${{ inputs.fail }}' `
+          -VerboseInput '${{ inputs.verbose }}'


### PR DESCRIPTION
This PR fixes several behavior and documentation gaps in the replace-tokens composite action.

## Changes

- fix dry-run reporting so files that would change are tracked separately from files that were written
- make `fail: true` work correctly with `dry-run: true`
- preserve platform-specific environment variable matching behavior
  - Windows: case-insensitive
  - Linux/macOS: case-sensitive
- run the composite action with Windows PowerShell on Windows and `pwsh` on Linux/macOS
- add composite action outputs for replacement and file counts
- make `paths` default to `.`
- add end-to-end coverage for `handlebars`, `brackets`, and `double-hashes`
- add regression coverage for dry-run and platform case-sensitivity behavior
- update README to document outputs, platform support, default path behavior, and dry-run fail semantics

## Validation

- ran `Invoke-Pester -Path ./Tests/Expand-TemplateFile.Tests.ps1 -Output Detailed`
- verified dry-run output reports:
  - `tokens-replaced`
  - `modified-files-count`
  - `would-modify-files-count`
- updated workflow coverage for Windows PowerShell and non-Windows runners

## Notes

- introduces `Invoke-ReplaceTokens.ps1` as the shared action runner
- adds pristine fixtures for `handlebars`, `brackets`, and `double-hashes`
