### PR TITLE
feat: update default file encoding to auto

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -89,7 +89,7 @@ body:
         recurse: false
         depth: 0
         follow-symlinks: false
-        encoding: utf8
+        encoding: auto
         no-newline: false
         dry-run: false
         fail: false

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -325,6 +325,129 @@ function Expand-TemplateFile
             return $false
         }
 
+        function Get-ByteOrderMarkInfo
+        {
+            param(
+                [System.IO.FileStream]
+                $Stream
+            )
+
+            $prefixBuffer = New-Object byte[] 4
+            $prefixBytesRead = $Stream.Read($prefixBuffer, 0, $prefixBuffer.Length)
+            $detectedName = $null
+            $preambleLength = 0
+
+            if ($prefixBytesRead -ge 4)
+            {
+                if ($prefixBuffer[0] -eq 0x00 -and $prefixBuffer[1] -eq 0x00 -and $prefixBuffer[2] -eq 0xFE -and $prefixBuffer[3] -eq 0xFF)
+                {
+                    $detectedName = 'bigendianutf32'
+                    $preambleLength = 4
+                }
+                elseif ($prefixBuffer[0] -eq 0xFF -and $prefixBuffer[1] -eq 0xFE -and $prefixBuffer[2] -eq 0x00 -and $prefixBuffer[3] -eq 0x00)
+                {
+                    $detectedName = 'utf32'
+                    $preambleLength = 4
+                }
+            }
+
+            if ($null -eq $detectedName -and $prefixBytesRead -ge 3)
+            {
+                if ($prefixBuffer[0] -eq 0xEF -and $prefixBuffer[1] -eq 0xBB -and $prefixBuffer[2] -eq 0xBF)
+                {
+                    $detectedName = 'utf8BOM'
+                    $preambleLength = 3
+                }
+            }
+
+            if ($null -eq $detectedName -and $prefixBytesRead -ge 2)
+            {
+                if ($prefixBuffer[0] -eq 0xFE -and $prefixBuffer[1] -eq 0xFF)
+                {
+                    $detectedName = 'bigendianunicode'
+                    $preambleLength = 2
+                }
+                elseif ($prefixBuffer[0] -eq 0xFF -and $prefixBuffer[1] -eq 0xFE)
+                {
+                    $detectedName = 'unicode'
+                    $preambleLength = 2
+                }
+            }
+
+            return [PSCustomObject]@{
+                Buffer = $prefixBuffer
+                BytesRead = $prefixBytesRead
+                Name = $detectedName
+                PreambleLength = $preambleLength
+            }
+        }
+
+        function Get-BomSkipLength
+        {
+            param(
+                [string]
+                $RequestedEncodingName,
+
+                [string]
+                $DetectedBomName,
+
+                [int]
+                $DetectedBomLength
+            )
+
+            if ([string]::IsNullOrWhiteSpace($DetectedBomName) -or $DetectedBomLength -le 0)
+            {
+                return 0
+            }
+
+            $requestedEncodingLower = $RequestedEncodingName.ToLower()
+            if ($requestedEncodingLower -eq 'auto')
+            {
+                return $DetectedBomLength
+            }
+
+            switch ($requestedEncodingLower)
+            {
+                { $_ -in @('utf8', 'utf-8', 'utf8nobom', 'utf8bom') }
+                {
+                    if ($DetectedBomName -eq 'utf8BOM')
+                    {
+                        return $DetectedBomLength
+                    }
+                }
+                'unicode'
+                {
+                    if ($DetectedBomName -eq 'unicode')
+                    {
+                        return $DetectedBomLength
+                    }
+                }
+                'bigendianunicode'
+                {
+                    if ($DetectedBomName -eq 'bigendianunicode')
+                    {
+                        return $DetectedBomLength
+                    }
+                }
+                'utf32'
+                {
+                    if ($DetectedBomName -eq 'utf32')
+                    {
+                        return $DetectedBomLength
+                    }
+                }
+                'bigendianutf32'
+                {
+                    if ($DetectedBomName -eq 'bigendianutf32')
+                    {
+                        return $DetectedBomLength
+                    }
+                }
+            }
+
+            return 0
+        }
+
         function Get-FileEncodingInfo
         {
             param(
@@ -336,13 +459,21 @@ function Expand-TemplateFile
             )
 
             $requestedEncodingLower = $RequestedEncodingName.ToLower()
+            $bomInfo = Get-ByteOrderMarkInfo -Stream $Stream
             if ($requestedEncodingLower -ne 'auto')
             {
-                return (Get-ExplicitEncodingInfo -EncodingName $RequestedEncodingName)
+                $explicitEncodingInfo = Get-ExplicitEncodingInfo -EncodingName $RequestedEncodingName
+
+                return [PSCustomObject]@{
+                    Name = $explicitEncodingInfo.Name
+                    ReadEncoding = $explicitEncodingInfo.ReadEncoding
+                    WriteEncoding = $explicitEncodingInfo.WriteEncoding
+                    BomLengthToSkip = (Get-BomSkipLength -RequestedEncodingName $RequestedEncodingName -DetectedBomName $bomInfo.Name -DetectedBomLength $bomInfo.PreambleLength)
+                }
             }
 
-            $prefixBuffer = New-Object byte[] 4
-            $prefixBytesRead = $Stream.Read($prefixBuffer, 0, $prefixBuffer.Length)
+            $prefixBuffer = $bomInfo.Buffer
+            $prefixBytesRead = $bomInfo.BytesRead
 
             if ($prefixBytesRead -ge 4)
             {
@@ -352,6 +483,7 @@ function Expand-TemplateFile
                         Name = 'bigendianutf32'
                         ReadEncoding = (Get-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
                         WriteEncoding = (Get-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
+                        BomLengthToSkip = $bomInfo.PreambleLength
                     }
                 }
 
@@ -361,6 +493,7 @@ function Expand-TemplateFile
                         Name = 'utf32'
                         ReadEncoding = (Get-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
                         WriteEncoding = (Get-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
+                        BomLengthToSkip = $bomInfo.PreambleLength
                     }
                 }
             }
@@ -373,6 +506,7 @@ function Expand-TemplateFile
                         Name = 'utf8BOM'
                         ReadEncoding = (Get-Utf8EncodingWithBom)
                         WriteEncoding = (Get-Utf8EncodingWithBom)
+                        BomLengthToSkip = $bomInfo.PreambleLength
                     }
                 }
             }
@@ -385,6 +519,7 @@ function Expand-TemplateFile
                         Name = 'bigendianunicode'
                         ReadEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
                         WriteEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
+                        BomLengthToSkip = $bomInfo.PreambleLength
                     }
                 }
 
@@ -394,6 +529,7 @@ function Expand-TemplateFile
                         Name = 'unicode'
                         ReadEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
                         WriteEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
+                        BomLengthToSkip = $bomInfo.PreambleLength
                     }
                 }
             }
@@ -404,6 +540,7 @@ function Expand-TemplateFile
                     Name = 'utf8'
                     ReadEncoding = (Get-Utf8EncodingNoBom)
                     WriteEncoding = (Get-Utf8EncodingNoBom)
+                    BomLengthToSkip = 0
                 }
             }
 
@@ -425,6 +562,7 @@ function Expand-TemplateFile
                     Name = 'unicode'
                     ReadEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
                     WriteEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
+                    BomLengthToSkip = 0
                 }
             }
 
@@ -434,6 +572,7 @@ function Expand-TemplateFile
                     Name = 'bigendianunicode'
                     ReadEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
                     WriteEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
+                    BomLengthToSkip = 0
                 }
             }
 
@@ -443,6 +582,7 @@ function Expand-TemplateFile
                     Name = 'utf8'
                     ReadEncoding = (Get-Utf8EncodingNoBom)
                     WriteEncoding = (Get-Utf8EncodingNoBom)
+                    BomLengthToSkip = 0
                 }
             }
 
@@ -453,6 +593,7 @@ function Expand-TemplateFile
                     Name = 'ansi'
                     ReadEncoding = $ansiEncoding
                     WriteEncoding = $ansiEncoding
+                    BomLengthToSkip = 0
                 }
             }
 
@@ -460,6 +601,7 @@ function Expand-TemplateFile
                 Name = 'utf8'
                 ReadEncoding = (Get-Utf8EncodingNoBom)
                 WriteEncoding = (Get-Utf8EncodingNoBom)
+                BomLengthToSkip = 0
             }
         }
 
@@ -480,7 +622,7 @@ function Expand-TemplateFile
             {
                 $fileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Open), ([System.IO.FileAccess]::Read), ([System.IO.FileShare]::ReadWrite)
                 $encodingInfo = Get-FileEncodingInfo -Stream $fileStream -RequestedEncodingName $RequestedEncodingName
-                $fileStream.Position = 0
+                $fileStream.Position = $encodingInfo.BomLengthToSkip
 
                 $reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $fileStream, $encodingInfo.ReadEncoding, $false
                 $content = $reader.ReadToEnd()

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -28,7 +28,7 @@ function Expand-TemplateFile
         Follow symbolic links when traversing directories.
 
     .PARAMETER Encoding
-        Specify the file encoding. Default: utf8
+        Specify the file encoding. Default: auto
 
     .PARAMETER NoNewline
         Do not add a newline at the end of the file.
@@ -92,9 +92,9 @@ function Expand-TemplateFile
         $FollowSymlinks,
 
         [Parameter(HelpMessage = 'Specify the file encoding')]
-        [ValidateSet('utf8', 'utf-8', 'utf8NoBOM', 'utf8BOM', 'ascii', 'ansi', 'bigendianunicode', 'bigendianutf32', 'oem', 'unicode', 'utf32', IgnoreCase = $true)]
+        [ValidateSet('auto', 'utf8', 'utf-8', 'utf8NoBOM', 'utf8BOM', 'ascii', 'ansi', 'bigendianunicode', 'bigendianutf32', 'oem', 'unicode', 'utf32', IgnoreCase = $true)]
         [string]
-        $Encoding = 'utf8',
+        $Encoding = 'auto',
 
         [Parameter(HelpMessage = 'Do not add a newline at the end of the file')]
         [switch]
@@ -116,6 +116,437 @@ function Expand-TemplateFile
 
             return [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
         }
+
+        function Register-CodePagesEncodingProvider
+        {
+            try
+            {
+                $providerType = [System.Type]::GetType('System.Text.CodePagesEncodingProvider, System.Text.Encoding.CodePages', $false)
+
+                if ($null -ne $providerType)
+                {
+                    [System.Text.Encoding]::RegisterProvider($providerType::Instance)
+                }
+            }
+            catch
+            {
+                Write-Verbose 'Code pages encoding provider registration was skipped.'
+            }
+        }
+
+        function New-Utf8EncodingNoBom
+        {
+            return (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true)
+        }
+
+        function New-Utf8EncodingWithBom
+        {
+            return (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $true, $true)
+        }
+
+        function New-UnicodeEncoding
+        {
+            param(
+                [bool]
+                $BigEndian,
+
+                [bool]
+                $ByteOrderMark
+            )
+
+            return (New-Object -TypeName System.Text.UnicodeEncoding -ArgumentList $BigEndian, $ByteOrderMark, $true)
+        }
+
+        function New-Utf32Encoding
+        {
+            param(
+                [bool]
+                $BigEndian,
+
+                [bool]
+                $ByteOrderMark
+            )
+
+            return (New-Object -TypeName System.Text.UTF32Encoding -ArgumentList $BigEndian, $ByteOrderMark, $true)
+        }
+
+        function Get-AnsiEncoding
+        {
+            if (-not (Test-IsWindows))
+            {
+                return (New-Utf8EncodingNoBom)
+            }
+
+            $ansiCodePage = [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ANSICodePage
+            return [System.Text.Encoding]::GetEncoding($ansiCodePage)
+        }
+
+        function Get-OemEncoding
+        {
+            if (-not (Test-IsWindows))
+            {
+                return (New-Utf8EncodingNoBom)
+            }
+
+            try
+            {
+                return [System.Text.Encoding]::GetEncoding([System.Console]::OutputEncoding.CodePage)
+            }
+            catch
+            {
+                return (Get-AnsiEncoding)
+            }
+        }
+
+        function Get-ExplicitEncodingInfo
+        {
+            param(
+                [string]
+                $EncodingName
+            )
+
+            $encodingLower = $EncodingName.ToLower()
+            $resolvedEncoding = switch ($encodingLower)
+            {
+                { $_ -in @('utf8', 'utf-8', 'utf8nobom') } { New-Utf8EncodingNoBom; break }
+                'utf8bom' { New-Utf8EncodingWithBom; break }
+                'ascii' { [System.Text.Encoding]::ASCII; break }
+                'ansi' { Get-AnsiEncoding; break }
+                'bigendianunicode' { New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true; break }
+                'bigendianutf32' { New-Utf32Encoding -BigEndian $true -ByteOrderMark $true; break }
+                'oem' { Get-OemEncoding; break }
+                'unicode' { New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true; break }
+                'utf32' { New-Utf32Encoding -BigEndian $false -ByteOrderMark $true; break }
+                default { throw "Unknown encoding: $EncodingName" }
+            }
+
+            return [PSCustomObject]@{
+                Name = $EncodingName
+                ReadEncoding = $resolvedEncoding
+                WriteEncoding = $resolvedEncoding
+            }
+        }
+
+        function Test-IsLikelyUtf16
+        {
+            param(
+                [byte[]]
+                $Bytes,
+
+                [int]
+                $Count,
+
+                [bool]
+                $BigEndian
+            )
+
+            if ($Count -lt 4)
+            {
+                return $false
+            }
+
+            $pairCount = [int][Math]::Floor($Count / 2)
+            $nullByteMatches = 0
+            $nonNullTextBytes = 0
+
+            for ($index = 0; $index -lt ($pairCount * 2); $index += 2)
+            {
+                if ($BigEndian)
+                {
+                    $nullByte = $Bytes[$index]
+                    $textByte = $Bytes[$index + 1]
+                }
+                else
+                {
+                    $textByte = $Bytes[$index]
+                    $nullByte = $Bytes[$index + 1]
+                }
+
+                if ($nullByte -eq 0 -and $textByte -ne 0)
+                {
+                    $nullByteMatches++
+                }
+
+                if ($textByte -ne 0)
+                {
+                    $nonNullTextBytes++
+                }
+            }
+
+            if ($nonNullTextBytes -lt 2)
+            {
+                return $false
+            }
+
+            return $nullByteMatches -ge [Math]::Max(2, [int][Math]::Floor($pairCount * 0.6))
+        }
+
+        function Test-IsLikelyUtf8
+        {
+            param(
+                [byte[]]
+                $Bytes,
+
+                [int]
+                $Count
+            )
+
+            if ($Count -le 0)
+            {
+                return $true
+            }
+
+            $strictUtf8 = New-Utf8EncodingNoBom
+
+            for ($trimCount = 0; $trimCount -le 3; $trimCount++)
+            {
+                $lengthToTest = $Count - $trimCount
+
+                if ($lengthToTest -le 0)
+                {
+                    continue
+                }
+
+                try
+                {
+                    [void]$strictUtf8.GetCharCount($Bytes, 0, $lengthToTest)
+                    return $true
+                }
+                catch [System.Text.DecoderFallbackException]
+                {
+                }
+                catch [System.ArgumentException]
+                {
+                }
+            }
+
+            return $false
+        }
+
+        function Get-FileEncodingInfo
+        {
+            param(
+                [System.IO.FileStream]
+                $Stream,
+
+                [string]
+                $RequestedEncodingName
+            )
+
+            $requestedEncodingLower = $RequestedEncodingName.ToLower()
+            if ($requestedEncodingLower -ne 'auto')
+            {
+                return (Get-ExplicitEncodingInfo -EncodingName $RequestedEncodingName)
+            }
+
+            $prefixBuffer = New-Object byte[] 4
+            $prefixBytesRead = $Stream.Read($prefixBuffer, 0, $prefixBuffer.Length)
+
+            if ($prefixBytesRead -ge 4)
+            {
+                if ($prefixBuffer[0] -eq 0x00 -and $prefixBuffer[1] -eq 0x00 -and $prefixBuffer[2] -eq 0xFE -and $prefixBuffer[3] -eq 0xFF)
+                {
+                    return [PSCustomObject]@{
+                        Name = 'bigendianutf32'
+                        ReadEncoding = (New-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
+                        WriteEncoding = (New-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
+                    }
+                }
+
+                if ($prefixBuffer[0] -eq 0xFF -and $prefixBuffer[1] -eq 0xFE -and $prefixBuffer[2] -eq 0x00 -and $prefixBuffer[3] -eq 0x00)
+                {
+                    return [PSCustomObject]@{
+                        Name = 'utf32'
+                        ReadEncoding = (New-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
+                        WriteEncoding = (New-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
+                    }
+                }
+            }
+
+            if ($prefixBytesRead -ge 3)
+            {
+                if ($prefixBuffer[0] -eq 0xEF -and $prefixBuffer[1] -eq 0xBB -and $prefixBuffer[2] -eq 0xBF)
+                {
+                    return [PSCustomObject]@{
+                        Name = 'utf8BOM'
+                        ReadEncoding = (New-Utf8EncodingWithBom)
+                        WriteEncoding = (New-Utf8EncodingWithBom)
+                    }
+                }
+            }
+
+            if ($prefixBytesRead -ge 2)
+            {
+                if ($prefixBuffer[0] -eq 0xFE -and $prefixBuffer[1] -eq 0xFF)
+                {
+                    return [PSCustomObject]@{
+                        Name = 'bigendianunicode'
+                        ReadEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
+                        WriteEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
+                    }
+                }
+
+                if ($prefixBuffer[0] -eq 0xFF -and $prefixBuffer[1] -eq 0xFE)
+                {
+                    return [PSCustomObject]@{
+                        Name = 'unicode'
+                        ReadEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
+                        WriteEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
+                    }
+                }
+            }
+
+            if ($prefixBytesRead -eq 0)
+            {
+                return [PSCustomObject]@{
+                    Name = 'utf8'
+                    ReadEncoding = (New-Utf8EncodingNoBom)
+                    WriteEncoding = (New-Utf8EncodingNoBom)
+                }
+            }
+
+            $sampleBuffer = New-Object byte[] 4096
+            [System.Array]::Copy($prefixBuffer, 0, $sampleBuffer, 0, $prefixBytesRead)
+
+            $remainingSampleCapacity = $sampleBuffer.Length - $prefixBytesRead
+            $additionalBytesRead = 0
+            if ($remainingSampleCapacity -gt 0)
+            {
+                $additionalBytesRead = $Stream.Read($sampleBuffer, $prefixBytesRead, $remainingSampleCapacity)
+            }
+
+            $totalSampleBytesRead = $prefixBytesRead + $additionalBytesRead
+
+            if (Test-IsLikelyUtf16 -Bytes $sampleBuffer -Count $totalSampleBytesRead -BigEndian $false)
+            {
+                return [PSCustomObject]@{
+                    Name = 'unicode'
+                    ReadEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
+                    WriteEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
+                }
+            }
+
+            if (Test-IsLikelyUtf16 -Bytes $sampleBuffer -Count $totalSampleBytesRead -BigEndian $true)
+            {
+                return [PSCustomObject]@{
+                    Name = 'bigendianunicode'
+                    ReadEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
+                    WriteEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
+                }
+            }
+
+            if (Test-IsLikelyUtf8 -Bytes $sampleBuffer -Count $totalSampleBytesRead)
+            {
+                return [PSCustomObject]@{
+                    Name = 'utf8'
+                    ReadEncoding = (New-Utf8EncodingNoBom)
+                    WriteEncoding = (New-Utf8EncodingNoBom)
+                }
+            }
+
+            if (Test-IsWindows)
+            {
+                $ansiEncoding = Get-AnsiEncoding
+                return [PSCustomObject]@{
+                    Name = 'ansi'
+                    ReadEncoding = $ansiEncoding
+                    WriteEncoding = $ansiEncoding
+                }
+            }
+
+            return [PSCustomObject]@{
+                Name = 'utf8'
+                ReadEncoding = (New-Utf8EncodingNoBom)
+                WriteEncoding = (New-Utf8EncodingNoBom)
+            }
+        }
+
+        function Read-FileContent
+        {
+            param(
+                [string]
+                $File,
+
+                [string]
+                $RequestedEncodingName
+            )
+
+            $fileStream = $null
+            $reader = $null
+
+            try
+            {
+                $fileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Open), ([System.IO.FileAccess]::Read), ([System.IO.FileShare]::ReadWrite)
+                $encodingInfo = Get-FileEncodingInfo -Stream $fileStream -RequestedEncodingName $RequestedEncodingName
+                $fileStream.Position = 0
+
+                $reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $fileStream, $encodingInfo.ReadEncoding, $true
+                $content = $reader.ReadToEnd()
+
+                return [PSCustomObject]@{
+                    Content = $content
+                    EncodingInfo = $encodingInfo
+                }
+            }
+            finally
+            {
+                if ($null -ne $reader)
+                {
+                    $reader.Dispose()
+                }
+                elseif ($null -ne $fileStream)
+                {
+                    $fileStream.Dispose()
+                }
+            }
+        }
+
+        function Write-FileContent
+        {
+            param(
+                [string]
+                $File,
+
+                [string]
+                $Content,
+
+                [System.Text.Encoding]
+                $EncodingObject,
+
+                [bool]
+                $NoNewline
+            )
+
+            $fileStream = $null
+            $writer = $null
+
+            try
+            {
+                $fileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Create), ([System.IO.FileAccess]::Write), ([System.IO.FileShare]::None)
+                $writer = New-Object -TypeName System.IO.StreamWriter -ArgumentList $fileStream, $EncodingObject
+
+                $writer.Write($Content)
+                if (-not $NoNewline)
+                {
+                    $writer.Write([Environment]::NewLine)
+                }
+
+                $writer.Flush()
+            }
+            finally
+            {
+                if ($null -ne $writer)
+                {
+                    $writer.Dispose()
+                }
+                elseif ($null -ne $fileStream)
+                {
+                    $fileStream.Dispose()
+                }
+            }
+        }
+
+        Register-CodePagesEncodingProvider
 
         # Validate that -Depth is only used with -Recurse
         if ($Depth -gt 0 -and -not $Recurse)
@@ -164,69 +595,8 @@ function Expand-TemplateFile
         $EnvVars = New-Object 'System.Collections.Generic.Dictionary[string,string]' $envComparer
         Get-ChildItem Env: | ForEach-Object { $EnvVars[$_.Name] = $_.Value }
 
-        # Helper function to normalize encoding settings
-        function Get-NormalizedEncoding
-        {
-            param ([string] $EncodingName)
-
-            $psVersion = $PSVersionTable.PSVersion.Major
-            $encodingLower = $EncodingName.ToLower()
-
-            # Create encoding configuration object
-            $config = [PSCustomObject]@{
-                FileEncoding = $EncodingName
-                StripBOM = $false
-                AddBOM = $false
-            }
-
-            # Handle UTF-8 variants based on PowerShell version
-            switch ($encodingLower)
-            {
-                { $_ -in @('utf8', 'utf-8', 'utf8nobom') }
-                {
-                    if ($psVersion -ge 6)
-                    {
-                        $config.FileEncoding = 'utf8NoBOM'
-                    }
-                    else
-                    {
-                        # PS 5.1: utf8 adds BOM, so we need to strip it manually
-                        $config.FileEncoding = 'utf8'
-                        $config.StripBOM = $true
-                    }
-                }
-                'utf8bom'
-                {
-                    if ($psVersion -ge 6)
-                    {
-                        # PS 6+: Manually add BOM
-                        $config.FileEncoding = 'utf8'
-                        $config.AddBOM = $true
-                    }
-                    else
-                    {
-                        # PS 5.1: utf8 encoding adds BOM by default
-                        $config.FileEncoding = 'utf8'
-                    }
-                }
-                'ansi'
-                {
-                    if ($psVersion -lt 6)
-                    {
-                        # PS 5.1 uses Default for the active ANSI code page
-                        $config.FileEncoding = 'Default'
-                    }
-                }
-            }
-
-            return $config
-        }
-
-        # Normalize encoding for PowerShell version compatibility
-        $encodingConfig = Get-NormalizedEncoding -EncodingName $Encoding
-
         # Function to replace tokens in a file
-        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string,string]] $EnvironmentVars, [PSCustomObject] $EncodingConfig, [bool] $NoNewline)
+        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string,string]] $EnvironmentVars, [string] $RequestedEncodingName, [bool] $NoNewline)
         {
             # Use script-scoped variables for per-file counters so they work inside scriptblocks
             $script:tokensInFile = 0
@@ -234,7 +604,9 @@ function Expand-TemplateFile
 
             try
             {
-                $content = Get-Content -Path $File -Raw -Encoding $EncodingConfig.FileEncoding -ErrorAction Stop
+                $fileState = Read-FileContent -File $File -RequestedEncodingName $RequestedEncodingName
+                $encodingInfo = $fileState.EncodingInfo
+                $content = $fileState.Content
                 $originalContent = $content
 
                 # Replace tokens using a regex evaluator with pre-compiled pattern
@@ -274,40 +646,11 @@ function Expand-TemplateFile
                     # Use ShouldProcess for -WhatIf support
                     if ($PSCmdlet.ShouldProcess($File, 'Replace tokens'))
                     {
-                        if ($EncodingConfig.StripBOM)
-                        {
-                            # For PowerShell 5.1, manually write without BOM
-                            $utf8NoBom = New-Object System.Text.UTF8Encoding $false
-                            if ($NoNewline)
-                            {
-                                [System.IO.File]::WriteAllText($File, $content, $utf8NoBom)
-                            }
-                            else
-                            {
-                                [System.IO.File]::WriteAllText($File, ($content + [Environment]::NewLine), $utf8NoBom)
-                            }
-                        }
-                        elseif ($EncodingConfig.AddBOM)
-                        {
-                            # Manually write with BOM (works in all PS versions)
-                            $utf8WithBom = New-Object System.Text.UTF8Encoding $true
-                            if ($NoNewline)
-                            {
-                                [System.IO.File]::WriteAllText($File, $content, $utf8WithBom)
-                            }
-                            else
-                            {
-                                [System.IO.File]::WriteAllText($File, ($content + [Environment]::NewLine), $utf8WithBom)
-                            }
-                        }
-                        else
-                        {
-                            Set-Content -Path $File -Value $content -Encoding $EncodingConfig.FileEncoding -NoNewline:$NoNewline -Force -ErrorAction Stop
-                        }
+                        Write-FileContent -File $File -Content $content -EncodingObject $encodingInfo.WriteEncoding -NoNewline $NoNewline
                         $modified = $true
                     }
 
-                    Write-Verbose "[$File] Replaced $($script:tokensInFile) token(s) (skipped $($script:skippedInFile))"
+                    Write-Verbose "[$File] Replaced $($script:tokensInFile) token(s) (skipped $($script:skippedInFile)) using $($encodingInfo.Name) encoding"
                 }
 
                 # Create result object for this file
@@ -350,7 +693,7 @@ function Expand-TemplateFile
         # Process each file
         foreach ($file in $files)
         {
-            ReplaceTokens -File $file.FullName -TokenRegex $CompiledRegex -EnvironmentVars $EnvVars -EncodingConfig $encodingConfig -NoNewline $NoNewline
+            ReplaceTokens -File $file.FullName -TokenRegex $CompiledRegex -EnvironmentVars $EnvVars -RequestedEncodingName $Encoding -NoNewline $NoNewline
         }
     }
 

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -134,17 +134,17 @@ function Expand-TemplateFile
             }
         }
 
-        function New-Utf8EncodingNoBom
+        function Get-Utf8EncodingNoBom
         {
             return (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false, $true)
         }
 
-        function New-Utf8EncodingWithBom
+        function Get-Utf8EncodingWithBom
         {
             return (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $true, $true)
         }
 
-        function New-UnicodeEncoding
+        function Get-UnicodeEncoding
         {
             param(
                 [bool]
@@ -157,7 +157,7 @@ function Expand-TemplateFile
             return (New-Object -TypeName System.Text.UnicodeEncoding -ArgumentList $BigEndian, $ByteOrderMark, $true)
         }
 
-        function New-Utf32Encoding
+        function Get-Utf32Encoding
         {
             param(
                 [bool]
@@ -174,7 +174,7 @@ function Expand-TemplateFile
         {
             if (-not (Test-IsWindows))
             {
-                return (New-Utf8EncodingNoBom)
+                return (Get-Utf8EncodingNoBom)
             }
 
             $ansiCodePage = [System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ANSICodePage
@@ -185,7 +185,7 @@ function Expand-TemplateFile
         {
             if (-not (Test-IsWindows))
             {
-                return (New-Utf8EncodingNoBom)
+                return (Get-Utf8EncodingNoBom)
             }
 
             try
@@ -208,15 +208,15 @@ function Expand-TemplateFile
             $encodingLower = $EncodingName.ToLower()
             $resolvedEncoding = switch ($encodingLower)
             {
-                { $_ -in @('utf8', 'utf-8', 'utf8nobom') } { New-Utf8EncodingNoBom; break }
-                'utf8bom' { New-Utf8EncodingWithBom; break }
+                { $_ -in @('utf8', 'utf-8', 'utf8nobom') } { Get-Utf8EncodingNoBom; break }
+                'utf8bom' { Get-Utf8EncodingWithBom; break }
                 'ascii' { [System.Text.Encoding]::ASCII; break }
                 'ansi' { Get-AnsiEncoding; break }
-                'bigendianunicode' { New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true; break }
-                'bigendianutf32' { New-Utf32Encoding -BigEndian $true -ByteOrderMark $true; break }
+                'bigendianunicode' { Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $true; break }
+                'bigendianutf32' { Get-Utf32Encoding -BigEndian $true -ByteOrderMark $true; break }
                 'oem' { Get-OemEncoding; break }
-                'unicode' { New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true; break }
-                'utf32' { New-Utf32Encoding -BigEndian $false -ByteOrderMark $true; break }
+                'unicode' { Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $true; break }
+                'utf32' { Get-Utf32Encoding -BigEndian $false -ByteOrderMark $true; break }
                 default { throw "Unknown encoding: $EncodingName" }
             }
 
@@ -296,7 +296,7 @@ function Expand-TemplateFile
                 return $true
             }
 
-            $strictUtf8 = New-Utf8EncodingNoBom
+            $strictUtf8 = Get-Utf8EncodingNoBom
 
             for ($trimCount = 0; $trimCount -le 3; $trimCount++)
             {
@@ -314,9 +314,11 @@ function Expand-TemplateFile
                 }
                 catch [System.Text.DecoderFallbackException]
                 {
+                    Write-Verbose 'UTF-8 detection skipped current sample because decoder fallback was triggered.'
                 }
                 catch [System.ArgumentException]
                 {
+                    Write-Verbose 'UTF-8 detection skipped current sample because the byte sequence ended mid-character.'
                 }
             }
 
@@ -348,8 +350,8 @@ function Expand-TemplateFile
                 {
                     return [PSCustomObject]@{
                         Name = 'bigendianutf32'
-                        ReadEncoding = (New-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
-                        WriteEncoding = (New-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
+                        ReadEncoding = (Get-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
+                        WriteEncoding = (Get-Utf32Encoding -BigEndian $true -ByteOrderMark $true)
                     }
                 }
 
@@ -357,8 +359,8 @@ function Expand-TemplateFile
                 {
                     return [PSCustomObject]@{
                         Name = 'utf32'
-                        ReadEncoding = (New-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
-                        WriteEncoding = (New-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
+                        ReadEncoding = (Get-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
+                        WriteEncoding = (Get-Utf32Encoding -BigEndian $false -ByteOrderMark $true)
                     }
                 }
             }
@@ -369,8 +371,8 @@ function Expand-TemplateFile
                 {
                     return [PSCustomObject]@{
                         Name = 'utf8BOM'
-                        ReadEncoding = (New-Utf8EncodingWithBom)
-                        WriteEncoding = (New-Utf8EncodingWithBom)
+                        ReadEncoding = (Get-Utf8EncodingWithBom)
+                        WriteEncoding = (Get-Utf8EncodingWithBom)
                     }
                 }
             }
@@ -381,8 +383,8 @@ function Expand-TemplateFile
                 {
                     return [PSCustomObject]@{
                         Name = 'bigendianunicode'
-                        ReadEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
-                        WriteEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
+                        ReadEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
+                        WriteEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $true)
                     }
                 }
 
@@ -390,8 +392,8 @@ function Expand-TemplateFile
                 {
                     return [PSCustomObject]@{
                         Name = 'unicode'
-                        ReadEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
-                        WriteEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
+                        ReadEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
+                        WriteEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $true)
                     }
                 }
             }
@@ -400,8 +402,8 @@ function Expand-TemplateFile
             {
                 return [PSCustomObject]@{
                     Name = 'utf8'
-                    ReadEncoding = (New-Utf8EncodingNoBom)
-                    WriteEncoding = (New-Utf8EncodingNoBom)
+                    ReadEncoding = (Get-Utf8EncodingNoBom)
+                    WriteEncoding = (Get-Utf8EncodingNoBom)
                 }
             }
 
@@ -421,8 +423,8 @@ function Expand-TemplateFile
             {
                 return [PSCustomObject]@{
                     Name = 'unicode'
-                    ReadEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
-                    WriteEncoding = (New-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
+                    ReadEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
+                    WriteEncoding = (Get-UnicodeEncoding -BigEndian $false -ByteOrderMark $false)
                 }
             }
 
@@ -430,8 +432,8 @@ function Expand-TemplateFile
             {
                 return [PSCustomObject]@{
                     Name = 'bigendianunicode'
-                    ReadEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
-                    WriteEncoding = (New-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
+                    ReadEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
+                    WriteEncoding = (Get-UnicodeEncoding -BigEndian $true -ByteOrderMark $false)
                 }
             }
 
@@ -439,8 +441,8 @@ function Expand-TemplateFile
             {
                 return [PSCustomObject]@{
                     Name = 'utf8'
-                    ReadEncoding = (New-Utf8EncodingNoBom)
-                    WriteEncoding = (New-Utf8EncodingNoBom)
+                    ReadEncoding = (Get-Utf8EncodingNoBom)
+                    WriteEncoding = (Get-Utf8EncodingNoBom)
                 }
             }
 
@@ -456,8 +458,8 @@ function Expand-TemplateFile
 
             return [PSCustomObject]@{
                 Name = 'utf8'
-                ReadEncoding = (New-Utf8EncodingNoBom)
-                WriteEncoding = (New-Utf8EncodingNoBom)
+                ReadEncoding = (Get-Utf8EncodingNoBom)
+                WriteEncoding = (Get-Utf8EncodingNoBom)
             }
         }
 
@@ -480,7 +482,7 @@ function Expand-TemplateFile
                 $encodingInfo = Get-FileEncodingInfo -Stream $fileStream -RequestedEncodingName $RequestedEncodingName
                 $fileStream.Position = 0
 
-                $reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $fileStream, $encodingInfo.ReadEncoding, $true
+                $reader = New-Object -TypeName System.IO.StreamReader -ArgumentList $fileStream, $encodingInfo.ReadEncoding, $false
                 $content = $reader.ReadToEnd()
 
                 return [PSCustomObject]@{
@@ -596,7 +598,7 @@ function Expand-TemplateFile
         Get-ChildItem Env: | ForEach-Object { $EnvVars[$_.Name] = $_.Value }
 
         # Function to replace tokens in a file
-        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string,string]] $EnvironmentVars, [string] $RequestedEncodingName, [bool] $NoNewline)
+        function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string, string]] $EnvironmentVars, [string] $RequestedEncodingName, [bool] $NoNewline)
         {
             # Use script-scoped variables for per-file counters so they work inside scriptblocks
             $script:tokensInFile = 0

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -112,7 +112,7 @@ param(
     $FollowSymlinks = 'false',
 
     [string]
-    $Encoding = 'utf8',
+    $Encoding = 'auto',
 
     [string]
     $NoNewline = 'false',

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [action.yml](action.yml).
 | `follow-symlinks` | Follow symbolic links            | boolean | false    | `false`    | `true`        |
 | `dry-run`         | Preview without modifying files  | boolean | false    | `false`    | `true`        |
 | `fail`            | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
-| `encoding`        | [File encoding](#file-encoding)  | string  | false    | `utf8`     | `unicode`     |
+| `encoding`        | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
 | `no-newline`      | Skip the final newline           | boolean | false    | `false`    | `true`        |
 | `verbose`         | Enable verbose logging           | boolean | false    | `false`    | `true`        |
 
@@ -286,6 +286,8 @@ steps:
 
 Specify the encoding used for file reads and writes.
 
+By default, the action uses `auto`, which sniffs a BOM with a minimal read, applies lightweight UTF-16/UTF-8 heuristics when no BOM is present, and then writes the file back using the detected encoding.
+
 ```yaml
 steps:
   - name: Set a non-default encoding option for reading/writing files
@@ -331,8 +333,9 @@ If an environment variable named `VARIABLE` exists, its value is used for replac
 
 ## File encoding
 
-The default encoding for file reads and writes is `utf8` without a byte order mark (BOM). The following `encoding` values are also supported.
+The default encoding for file reads and writes is `auto`. In auto mode, the action first checks for a BOM, then uses lightweight heuristics for common no-BOM UTF-16 and UTF-8 files, and finally falls back to the Windows ANSI code page on Windows or UTF-8 without BOM on Linux and macOS. The following explicit `encoding` values are also supported.
 
+- `auto`: Detects the existing file encoding and writes the updated file back using that encoding when possible
 - `utf8`: Encodes as UTF-8 without a byte order mark (BOM)
 - `utf8BOM`: Encodes as UTF-8 with a byte order mark (BOM)
 - `ascii`: Uses the ASCII (7-bit) character set
@@ -343,7 +346,7 @@ The default encoding for file reads and writes is `utf8` without a byte order ma
 - `unicode`: Encodes as UTF-16 using little-endian byte order
 - `utf32`: Encodes as UTF-32
 
-On Windows PowerShell 5.1, `ansi` is normalized to `Default`, and UTF-8 BOM behavior is normalized internally so `utf8` remains BOM-less by default while `utf8BOM` writes a BOM.
+On Windows PowerShell 5.1, the action uses explicit .NET encodings internally so `auto`, `utf8`, and `utf8BOM` behave consistently with PowerShell Core while still preserving Windows ANSI fallback behavior when auto-detecting no-BOM files.
 
 ## License
 

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -263,6 +263,24 @@ Describe 'Expand-TemplateFile Function' {
         (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
     }
 
+    It 'Does not let a BOM override an explicit encoding request' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'explicit-encoding-overrides-bom.txt'
+        $unicodeEncoding = New-Object System.Text.UnicodeEncoding $false, $true
+        Write-EncodedContent -Path $testFile -Value 'Hello, {{NAME}}!' -Encoding $unicodeEncoding -NoNewline
+
+        $env:NAME = 'Elm'
+
+        # Act
+        $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8' -NoNewline -ErrorAction SilentlyContinue
+        $content = [System.IO.File]::ReadAllText($testFile, $unicodeEncoding)
+
+        # Assert
+        $content | Should -Be 'Hello, {{NAME}}!'
+        $result | Should -BeNullOrEmpty
+        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
+    }
+
     It 'Falls back to ANSI for no-BOM files on Windows when auto encoding is used' -Skip:(-not $script:isWindowsPlatform) {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'auto-ansi.txt'

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'Expand-TemplateFile Function' {
             return [System.Text.Encoding]::GetEncoding([System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ANSICodePage)
         }
 
-        function Test-FileStartsWithBytes
+        function Test-FileStartsWithPrefix
         {
             param(
                 [string]$Path,
@@ -226,7 +226,7 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Hello, Aster!'
         $result[0].TokensReplaced | Should -Be 1
         $result[0].Modified | Should -Be $true
-        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $false
+        (Test-FileStartsWithPrefix -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $false
     }
 
     It 'Preserves UTF-8 BOM files when auto encoding is used' {
@@ -243,7 +243,7 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $content | Should -Be 'Hello, Briar!'
-        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $true
+        (Test-FileStartsWithPrefix -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $true
     }
 
     It 'Preserves UTF-16 LE BOM files when auto encoding is used' {
@@ -260,7 +260,7 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $content | Should -Be 'Hello, Cedar!'
-        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
+        (Test-FileStartsWithPrefix -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
     }
 
     It 'Does not let a BOM override an explicit encoding request' {
@@ -278,7 +278,7 @@ Describe 'Expand-TemplateFile Function' {
         # Assert
         $content | Should -Be 'Hello, {{NAME}}!'
         $result | Should -BeNullOrEmpty
-        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
+        (Test-FileStartsWithPrefix -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
     }
 
     It 'Falls back to ANSI for no-BOM files on Windows when auto encoding is used' -Skip:(-not $script:isWindowsPlatform) {
@@ -498,7 +498,8 @@ Describe 'Expand-TemplateFile Function' {
     It 'Ensures utf8 encoding produces no BOM regardless of PowerShell version' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'utf8-no-bom.txt'
-        Set-Content -Path $testFile -Value 'Test {{VAR}} content' -Encoding utf8 -NoNewline
+        $utf8Bom = New-Object System.Text.UTF8Encoding $true
+        Write-EncodedContent -Path $testFile -Value 'Test {{VAR}} content' -Encoding $utf8Bom -NoNewline
 
         $env:VAR = 'Replaced'
 
@@ -518,7 +519,8 @@ Describe 'Expand-TemplateFile Function' {
     It 'Ensures utf8NoBOM encoding produces no BOM regardless of PowerShell version' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'utf8nobom-no-bom.txt'
-        Set-Content -Path $testFile -Value 'Test {{VAR2}} content' -Encoding utf8 -NoNewline
+        $utf8Bom = New-Object System.Text.UTF8Encoding $true
+        Write-EncodedContent -Path $testFile -Value 'Test {{VAR2}} content' -Encoding $utf8Bom -NoNewline
 
         $env:VAR2 = 'Replaced2'
 

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -6,6 +6,15 @@ if (-not (Get-Module -Name Pester -ListAvailable))
     Install-Module -Name Pester -Force -SkipPublisherCheck
 }
 
+$script:isWindowsPlatform = if (Get-Variable -Name IsWindows -ErrorAction SilentlyContinue)
+{
+    [bool]$IsWindows
+}
+else
+{
+    [System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT
+}
+
 Describe 'Expand-TemplateFile Function' {
 
     BeforeAll {
@@ -43,6 +52,59 @@ Describe 'Expand-TemplateFile Function' {
             {
                 [System.IO.File]::WriteAllText($Path, ($Value + [Environment]::NewLine), $utf8NoBom)
             }
+        }
+
+        function Write-EncodedContent
+        {
+            param(
+                [string]$Path,
+                [string]$Value,
+                [System.Text.Encoding]$Encoding,
+                [switch]$NoNewline
+            )
+
+            if ($NoNewline)
+            {
+                [System.IO.File]::WriteAllText($Path, $Value, $Encoding)
+            }
+            else
+            {
+                [System.IO.File]::WriteAllText($Path, ($Value + [Environment]::NewLine), $Encoding)
+            }
+        }
+
+        function Get-AnsiEncoding
+        {
+            if (-not (Test-IsWindows))
+            {
+                return (New-Object System.Text.UTF8Encoding $false)
+            }
+
+            return [System.Text.Encoding]::GetEncoding([System.Globalization.CultureInfo]::CurrentCulture.TextInfo.ANSICodePage)
+        }
+
+        function Test-FileStartsWithBytes
+        {
+            param(
+                [string]$Path,
+                [byte[]]$Prefix
+            )
+
+            $bytes = [System.IO.File]::ReadAllBytes($Path)
+            if ($bytes.Length -lt $Prefix.Length)
+            {
+                return $false
+            }
+
+            for ($index = 0; $index -lt $Prefix.Length; $index++)
+            {
+                if ($bytes[$index] -ne $Prefix[$index])
+                {
+                    return $false
+                }
+            }
+
+            return $true
         }
 
         # Store list of test environment variables for cleanup
@@ -147,6 +209,75 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Hello, Avery!'
         $result[0].TokensReplaced | Should -Be 1
         $result[0].Modified | Should -Be $true
+    }
+
+    It 'Uses auto encoding by default for UTF-8 without BOM files' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'auto-utf8-no-bom.txt'
+        Write-Utf8Content -Path $testFile -Value 'Hello, {{NAME}}!' -NoNewline
+
+        $env:NAME = 'Aster'
+
+        # Act
+        $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -NoNewline
+        $content = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $content | Should -Be 'Hello, Aster!'
+        $result[0].TokensReplaced | Should -Be 1
+        $result[0].Modified | Should -Be $true
+        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $false
+    }
+
+    It 'Preserves UTF-8 BOM files when auto encoding is used' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'auto-utf8-bom.txt'
+        $utf8Bom = New-Object System.Text.UTF8Encoding $true
+        Write-EncodedContent -Path $testFile -Value 'Hello, {{NAME}}!' -Encoding $utf8Bom -NoNewline
+
+        $env:NAME = 'Briar'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -NoNewline
+        $content = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $content | Should -Be 'Hello, Briar!'
+        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xEF, 0xBB, 0xBF))) | Should -Be $true
+    }
+
+    It 'Preserves UTF-16 LE BOM files when auto encoding is used' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'auto-unicode.txt'
+        $unicodeEncoding = New-Object System.Text.UnicodeEncoding $false, $true
+        Write-EncodedContent -Path $testFile -Value 'Hello, {{NAME}}!' -Encoding $unicodeEncoding -NoNewline
+
+        $env:NAME = 'Cedar'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -NoNewline
+        $content = [System.IO.File]::ReadAllText($testFile, $unicodeEncoding)
+
+        # Assert
+        $content | Should -Be 'Hello, Cedar!'
+        (Test-FileStartsWithBytes -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
+    }
+
+    It 'Falls back to ANSI for no-BOM files on Windows when auto encoding is used' -Skip:(-not $script:isWindowsPlatform) {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'auto-ansi.txt'
+        $ansiEncoding = Get-AnsiEncoding
+        $ansiSample = 'Cafe' + [char]0x00E9 + ' {{NAME}}!'
+        Write-EncodedContent -Path $testFile -Value $ansiSample -Encoding $ansiEncoding -NoNewline
+
+        $env:NAME = 'Dune'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -NoNewline
+        $content = [System.IO.File]::ReadAllText($testFile, $ansiEncoding)
+
+        # Assert
+        $content | Should -Be ('Cafe' + [char]0x00E9 + ' Dune!')
     }
 
     It 'Replaces tokens with envsubst style' {

--- a/action.yml
+++ b/action.yml
@@ -64,10 +64,10 @@ inputs:
   encoding:
     description: >-
       File encoding to use when reading and writing files.
-      Defaults to `utf8` without a byte order mark (BOM).
-      Accepted values: `utf8`, `utf8BOM`, `ascii`, `ansi`, `bigendianunicode`, `bigendianutf32`, `oem`, `unicode`, `utf32`
+      Defaults to `auto`, which attempts to preserve the file's existing encoding.
+      Accepted values: `auto`, `utf8`, `utf8BOM`, `ascii`, `ansi`, `bigendianunicode`, `bigendianutf32`, `oem`, `unicode`, `utf32`
     required: false
-    default: 'utf8'
+    default: 'auto'
 
   no-newline:
     description: >-


### PR DESCRIPTION
## Summary

Change the action's default `encoding` from `utf8` to `auto`, so files are read and written using their existing encoding unless an explicit encoding is provided.

## What changed

- Default `encoding` is now `auto`
- Added minimal BOM sniffing for UTF-8, UTF-16, and UTF-32 detection
- Added lightweight no-BOM heuristics for UTF-16 and UTF-8 files
- Preserved detected encoding when writing updated files
- Kept explicit `encoding` input behavior unchanged
- Reworked file I/O to use explicit .NET encodings for consistent PowerShell 5.1 and PowerShell Core behavior
- Updated docs and action metadata to describe the new default

## Compatibility

This is not a breaking change.

Existing callers that do not specify `encoding` now get better default behavior because the action preserves the target file's encoding instead of forcing UTF-8. Callers that already set `encoding` continue to behave as before.

## Tests

Added coverage for:

- auto-detecting UTF-8 without BOM
- preserving UTF-8 with BOM
- preserving UTF-16 LE with BOM
- Windows-only ANSI fallback for no-BOM files