### PR TITLE
feat: fail-on-skipped and preserve EOF newline behavior

### DIFF
--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -31,7 +31,7 @@ function Expand-TemplateFile
         Specify the file encoding. Default: auto
 
     .PARAMETER NoNewline
-        Do not add a newline at the end of the file.
+        Do not append a newline at the end of the file when writing changes.
 
     .PARAMETER Exclude
         Specify files or directories to exclude from processing.
@@ -60,7 +60,7 @@ function Expand-TemplateFile
     .OUTPUTS
         PSCustomObject[]
         Returns an array of objects with file processing details.
-        Each object contains: FilePath, TokensReplaced, TokensSkipped, Modified
+        Each object contains: FilePath, TokensReplaced, TokensSkipped, WouldModify, Modified
     #>
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([PSCustomObject[]])]
@@ -96,7 +96,7 @@ function Expand-TemplateFile
         [string]
         $Encoding = 'auto',
 
-        [Parameter(HelpMessage = 'Do not add a newline at the end of the file')]
+        [Parameter(HelpMessage = 'Do not append a newline at the end of the file when writing changes')]
         [switch]
         $NoNewline,
 
@@ -666,14 +666,23 @@ function Expand-TemplateFile
 
             try
             {
+                $finalContent = $Content
+                if (-not $NoNewline)
+                {
+                    $endsWithCrLf = $finalContent.EndsWith("`r`n", [System.StringComparison]::Ordinal)
+                    $endsWithLf = $finalContent.EndsWith("`n", [System.StringComparison]::Ordinal)
+                    $endsWithCr = $finalContent.EndsWith("`r", [System.StringComparison]::Ordinal)
+
+                    if (-not ($endsWithCrLf -or $endsWithLf -or $endsWithCr))
+                    {
+                        $finalContent += [Environment]::NewLine
+                    }
+                }
+
                 $fileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Create), ([System.IO.FileAccess]::Write), ([System.IO.FileShare]::None)
                 $writer = New-Object -TypeName System.IO.StreamWriter -ArgumentList $fileStream, $EncodingObject
 
-                $writer.Write($Content)
-                if (-not $NoNewline)
-                {
-                    $writer.Write([Environment]::NewLine)
-                }
+                $writer.Write($finalContent)
 
                 $writer.Flush()
             }

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -52,6 +52,11 @@
         A string boolean value that causes the script to exit with code 1 when no
         files are changed, or when DryRun is true, when no files would change.
 
+    .PARAMETER FailOnSkipped
+        A string boolean value that causes the script to exit with code 1 when one
+        or more tokens are skipped because a matching environment variable was not
+        available.
+
     .PARAMETER VerboseInput
         A string boolean value that enables verbose output from
         Expand-TemplateFile.ps1.
@@ -88,6 +93,12 @@
 
         Runs the helper the same way the composite action does and writes action
         outputs to the file referenced by GITHUB_OUTPUT.
+
+    .EXAMPLE
+        ./Invoke-ReplaceTokens.ps1 -PathsInput './template.txt' -FailOnSkipped true
+
+        Fails the command if any token is left unresolved because a matching
+        environment variable is missing or empty.
 #>
 param(
     [string]
@@ -122,6 +133,9 @@ param(
 
     [string]
     $Fail = 'false',
+
+    [string]
+    $FailOnSkipped = 'false',
 
     [string]
     $VerboseInput = 'false'
@@ -173,6 +187,7 @@ if ($paths.Count -eq 0)
 $exclude = Split-MultilineInput -Value $ExcludeInput
 $dryRunEnabled = [System.Convert]::ToBoolean($DryRun)
 $failEnabled = [System.Convert]::ToBoolean($Fail)
+$failOnSkippedEnabled = [System.Convert]::ToBoolean($FailOnSkipped)
 
 $params = @{
     Path = $paths
@@ -226,12 +241,6 @@ if ($null -eq $totalTokensSkipped)
     $totalTokensSkipped = 0
 }
 
-if ($failEnabled -and $reportedFiles.Count -eq 0)
-{
-    Write-Output '::error title=No operation performed::Ensure your token file paths are correct, and you have defined the appropriate tokens to replace.'
-    exit 1
-}
-
 $summaryPrefix = if ($dryRunEnabled)
 {
     'Tokens would be replaced in the following file(s):'
@@ -257,3 +266,15 @@ Write-ActionOutput -Name 'tokens-replaced' -Value $totalTokensReplaced
 Write-ActionOutput -Name 'tokens-skipped' -Value $totalTokensSkipped
 Write-ActionOutput -Name 'modified-files-count' -Value $modifiedFiles.Count
 Write-ActionOutput -Name 'would-modify-files-count' -Value $wouldModifyFiles.Count
+
+if ($failEnabled -and $reportedFiles.Count -eq 0)
+{
+    Write-Output '::error title=No operation performed::Ensure your token file paths are correct, and you have defined the appropriate tokens to replace.'
+    exit 1
+}
+
+if ($failOnSkippedEnabled -and $totalTokensSkipped -gt 0)
+{
+    Write-Output '::error title=Unresolved tokens::One or more tokens were skipped because a matching value was not available.'
+    exit 1
+}

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -55,7 +55,7 @@
     .PARAMETER FailOnSkipped
         A string boolean value that causes the script to exit with code 1 when one
         or more tokens are skipped because a matching environment variable was not
-        available.
+        available or its value was empty.
 
     .PARAMETER VerboseInput
         A string boolean value that enables verbose output from

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [Exclude items and patterns](#exclude-items-and-patterns)
   - [Preview changes with dry-run](#preview-changes-with-dry-run)
   - [Fail on no-op](#fail-on-no-op)
+  - [Fail on unresolved tokens](#fail-on-unresolved-tokens)
   - [Custom file encoding](#custom-file-encoding)
   - [No newline at EOF](#no-newline-at-eof)
 - [Token style](#token-style)
@@ -41,6 +42,7 @@ See [action.yml](action.yml).
 | `follow-symlinks` | Follow symbolic links            | boolean | false    | `false`    | `true`        |
 | `dry-run`         | Preview without modifying files  | boolean | false    | `false`    | `true`        |
 | `fail`            | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
+| `fail-on-skipped` | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
 | `encoding`        | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
 | `no-newline`      | Skip the final newline           | boolean | false    | `false`    | `true`        |
 | `verbose`         | Enable verbose logging           | boolean | false    | `false`    | `true`        |
@@ -282,6 +284,22 @@ steps:
 > [!NOTE]  
 > A warning is written to the log when a token does not have a matching environment variable.
 
+### Fail on unresolved tokens
+
+Fail the step if one or more tokens are skipped because a matching environment variable is missing or empty.
+
+```yaml
+steps:
+  - name: Fail when a token cannot be resolved
+    uses: jonlabelle/replace-tokens-action@v1
+    with:
+      paths: ./path/to/search
+      filter: '*.json'
+      fail-on-skipped: true
+    env:
+      NAME: jon
+```
+
 ### Custom file encoding
 
 Specify the encoding used for file reads and writes.
@@ -302,7 +320,9 @@ steps:
 
 ### No newline at EOF
 
-Do not add a trailing newline after token replacement.
+Do not append a trailing newline after token replacement.
+
+By default, the action preserves an existing trailing newline and avoids appending a duplicate newline when the file already ends with one.
 
 ```yaml
 steps:

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -107,6 +107,11 @@ Describe 'Expand-TemplateFile Function' {
             return $true
         }
 
+        function Get-CurrentPowerShellPath
+        {
+            return (Get-Process -Id $PID).Path
+        }
+
         # Store list of test environment variables for cleanup
         $script:testEnvVars = @(
             'NAME', 'ID', 'VALID_NAME', '_TEST_VAR', 'SPECIAL',
@@ -700,6 +705,67 @@ Describe 'Expand-TemplateFile Function' {
             $result[0].TokensReplaced | Should -Be 0
             $result[0].Modified | Should -Be $false
         }
+    }
+
+    It 'Preserves an existing trailing newline without appending a duplicate newline' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'preserve-trailing-newline.txt'
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($testFile, "Line {{VAR}}`r`n", $utf8NoBom)
+
+        $env:VAR = 'Done'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM'
+        $content = [System.IO.File]::ReadAllText($testFile, $utf8NoBom)
+
+        # Assert
+        $content | Should -Be "Line Done`r`n"
+    }
+
+    It 'Invoke-ReplaceTokens fails when fail-on-skipped is enabled and tokens are unresolved' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'fail-on-skipped.txt'
+        $outputFile = Join-Path -Path $testDir -ChildPath 'fail-on-skipped-output.txt'
+        $scriptPath = Join-Path -Path (Get-Item -Path $PSScriptRoot).Parent.FullName -ChildPath 'Invoke-ReplaceTokens.ps1'
+        $powershellPath = Get-CurrentPowerShellPath
+        Write-Utf8Content -Path $testFile -Value 'Hello {{NAME}} {{MISSING_TOKEN}}' -NoNewline
+
+        $env:NAME = 'Avery'
+
+        if (Test-Path -Path $outputFile)
+        {
+            Remove-Item -Path $outputFile -Force
+        }
+
+        $previousGithubOutput = $env:GITHUB_OUTPUT
+        $env:GITHUB_OUTPUT = $outputFile
+
+        try
+        {
+            $commandOutput = & $powershellPath -NoProfile -File $scriptPath -PathsInput $testFile -Style 'mustache' -NoNewline 'true' -FailOnSkipped 'true' 2>&1 | Out-String
+            $exitCode = $LASTEXITCODE
+        }
+        finally
+        {
+            if ([string]::IsNullOrWhiteSpace($previousGithubOutput))
+            {
+                Remove-Item Env:GITHUB_OUTPUT -ErrorAction SilentlyContinue
+            }
+            else
+            {
+                $env:GITHUB_OUTPUT = $previousGithubOutput
+            }
+        }
+
+        # Assert
+        $exitCode | Should -Be 1
+        $commandOutput | Should -Match 'Unresolved tokens'
+        $commandOutput | Should -Match 'Skipped: 1'
+
+        $actionOutput = Get-Content -Path $outputFile -Raw
+        $actionOutput | Should -Match 'tokens-skipped=1'
+        $actionOutput | Should -Match 'tokens-replaced=1'
     }
 
     It 'Throws error when -Depth is used without -Recurse' {

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -109,7 +109,29 @@ Describe 'Expand-TemplateFile Function' {
 
         function Get-CurrentPowerShellPath
         {
-            return (Get-Process -Id $PID).Path
+            $commandNames = @()
+
+            if ($PSVersionTable.PSEdition -eq 'Core')
+            {
+                $commandNames += 'pwsh'
+                $commandNames += 'powershell'
+            }
+            else
+            {
+                $commandNames += 'powershell'
+                $commandNames += 'pwsh'
+            }
+
+            foreach ($commandName in $commandNames)
+            {
+                $command = Get-Command -Name $commandName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -ne $command)
+                {
+                    return $command.Source
+                }
+            }
+
+            throw 'Unable to resolve a PowerShell executable for the fail-on-skipped test.'
         }
 
         # Store list of test environment variables for cleanup

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ inputs:
   fail-on-skipped:
     description: >-
       Fail the step if one or more tokens are skipped because a matching value
-      was not available.
+      was missing or empty.
     required: false
     default: 'false'
 

--- a/action.yml
+++ b/action.yml
@@ -71,8 +71,9 @@ inputs:
 
   no-newline:
     description: >-
-      Do not add a trailing newline to the file.
-      By default, a trailing newline is added.
+      Do not append a trailing newline to the file.
+      By default, an existing trailing newline is preserved and a newline is
+      appended only when the file does not already end with one.
     required: false
     default: 'false'
 
@@ -88,6 +89,13 @@ inputs:
     description: >-
       Fail the step if no files were changed.
       When `dry-run` is enabled, fail if no files would change.
+    required: false
+    default: 'false'
+
+  fail-on-skipped:
+    description: >-
+      Fail the step if one or more tokens are skipped because a matching value
+      was not available.
     required: false
     default: 'false'
 
@@ -148,4 +156,5 @@ runs:
           -NoNewline '${{ inputs.no-newline }}' `
           -DryRun '${{ inputs.dry-run }}' `
           -Fail '${{ inputs.fail }}' `
+          -FailOnSkipped '${{ inputs.fail-on-skipped }}' `
           -VerboseInput '${{ inputs.verbose }}'


### PR DESCRIPTION
## Summary

This PR adds a strict failure mode for unresolved tokens and improves file writing behavior so existing EOF newlines are preserved without appending duplicate newlines.

## Changes

- add a new `fail-on-skipped` input to the action
- fail the action when one or more tokens are skipped because a matching environment variable is missing or empty
- preserve an existing trailing newline when rewriting files
- avoid appending an extra newline when the file already ends with one
- update the PowerShell helper and function help text to reflect the new behavior
- update the README with usage examples and behavior notes
- add regression tests for:
  - `fail-on-skipped`
  - trailing newline preservation

## Why

The new strict mode makes CI safer for teams that want template expansion to be all-or-nothing.

The newline change reduces noisy diffs and avoids modifying files more than necessary during replacement.

## Notes

- `fail` behavior is unchanged
- `fail-on-skipped` is opt-in and defaults to `false`
- `no-newline: true` still disables trailing newline output entirely