### PR TITLE
feat: infer existing newlines

### DIFF
--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -630,6 +630,7 @@ function Expand-TemplateFile
                 return [PSCustomObject]@{
                     Content = $content
                     EncodingInfo = $encodingInfo
+                    NewlineSequence = (Get-PreferredNewlineSequence -Content $content)
                 }
             }
             finally
@@ -645,6 +646,61 @@ function Expand-TemplateFile
             }
         }
 
+        function Get-PreferredNewlineSequence
+        {
+            param(
+                [string]
+                $Content
+            )
+
+            if ([string]::IsNullOrEmpty($Content))
+            {
+                return $null
+            }
+
+            $crLfCount = 0
+            $lfCount = 0
+            $crCount = 0
+
+            for ($index = 0; $index -lt $Content.Length; $index++)
+            {
+                if ($Content[$index] -eq "`r")
+                {
+                    if (($index + 1) -lt $Content.Length -and $Content[$index + 1] -eq "`n")
+                    {
+                        $crLfCount++
+                        $index++
+                        continue
+                    }
+
+                    $crCount++
+                    continue
+                }
+
+                if ($Content[$index] -eq "`n")
+                {
+                    $lfCount++
+                }
+            }
+
+            if ($crLfCount -eq 0 -and $lfCount -eq 0 -and $crCount -eq 0)
+            {
+                return $null
+            }
+
+            if ($crLfCount -ge $lfCount -and $crLfCount -ge $crCount)
+            {
+                return "`r`n"
+            }
+
+            if ($lfCount -ge $crCount)
+            {
+                return "`n"
+            }
+
+            return "`r"
+        }
+
         function Write-FileContent
         {
             param(
@@ -656,6 +712,9 @@ function Expand-TemplateFile
 
                 [System.Text.Encoding]
                 $EncodingObject,
+
+                [string]
+                $NewlineSequence,
 
                 [bool]
                 $NoNewline
@@ -675,7 +734,14 @@ function Expand-TemplateFile
 
                     if (-not ($endsWithCrLf -or $endsWithLf -or $endsWithCr))
                     {
-                        $finalContent += [Environment]::NewLine
+                        if ([string]::IsNullOrEmpty($NewlineSequence))
+                        {
+                            $finalContent += [Environment]::NewLine
+                        }
+                        else
+                        {
+                            $finalContent += $NewlineSequence
+                        }
                     }
                 }
 
@@ -760,6 +826,7 @@ function Expand-TemplateFile
                 $fileState = Read-FileContent -File $File -RequestedEncodingName $RequestedEncodingName
                 $encodingInfo = $fileState.EncodingInfo
                 $content = $fileState.Content
+                $newlineSequence = $fileState.NewlineSequence
                 $originalContent = $content
 
                 # Replace tokens using a regex evaluator with pre-compiled pattern
@@ -799,7 +866,7 @@ function Expand-TemplateFile
                     # Use ShouldProcess for -WhatIf support
                     if ($PSCmdlet.ShouldProcess($File, 'Replace tokens'))
                     {
-                        Write-FileContent -File $File -Content $content -EncodingObject $encodingInfo.WriteEncoding -NoNewline $NoNewline
+                        Write-FileContent -File $File -Content $content -EncodingObject $encodingInfo.WriteEncoding -NewlineSequence $newlineSequence -NoNewline $NoNewline
                         $modified = $true
                     }
 

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -630,7 +630,6 @@ function Expand-TemplateFile
                 return [PSCustomObject]@{
                     Content = $content
                     EncodingInfo = $encodingInfo
-                    NewlineSequence = (Get-PreferredNewlineSequence -Content $content)
                 }
             }
             finally
@@ -714,7 +713,7 @@ function Expand-TemplateFile
                 $EncodingObject,
 
                 [string]
-                $NewlineSequence,
+                $OriginalContent,
 
                 [bool]
                 $NoNewline
@@ -734,6 +733,8 @@ function Expand-TemplateFile
 
                     if (-not ($endsWithCrLf -or $endsWithLf -or $endsWithCr))
                     {
+                        $newlineSequence = Get-PreferredNewlineSequence -Content $OriginalContent
+
                         if ([string]::IsNullOrEmpty($NewlineSequence))
                         {
                             $finalContent += [Environment]::NewLine
@@ -826,7 +827,6 @@ function Expand-TemplateFile
                 $fileState = Read-FileContent -File $File -RequestedEncodingName $RequestedEncodingName
                 $encodingInfo = $fileState.EncodingInfo
                 $content = $fileState.Content
-                $newlineSequence = $fileState.NewlineSequence
                 $originalContent = $content
 
                 # Replace tokens using a regex evaluator with pre-compiled pattern
@@ -866,7 +866,7 @@ function Expand-TemplateFile
                     # Use ShouldProcess for -WhatIf support
                     if ($PSCmdlet.ShouldProcess($File, 'Replace tokens'))
                     {
-                        Write-FileContent -File $File -Content $content -EncodingObject $encodingInfo.WriteEncoding -NewlineSequence $newlineSequence -NoNewline $NoNewline
+                        Write-FileContent -File $File -Content $content -EncodingObject $encodingInfo.WriteEncoding -OriginalContent $originalContent -NoNewline $NoNewline
                         $modified = $true
                     }
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ steps:
 
 Do not append a trailing newline after token replacement.
 
-By default, the action preserves an existing trailing newline and avoids appending a duplicate newline when the file already ends with one.
+By default, the action preserves an existing trailing newline, avoids appending a duplicate newline when the file already ends with one, and reuses the file's detected line ending style when a trailing newline needs to be added. If no existing line ending can be inferred, it falls back to the runner environment newline.
 
 ```yaml
 steps:

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -745,6 +745,55 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be "Line Done`r`n"
     }
 
+    It 'Appends a trailing newline using the existing CRLF line ending style' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'append-existing-crlf-newline.txt'
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($testFile, "Line {{VAR}}`r`nNext {{VAR}}", $utf8NoBom)
+
+        $env:VAR = 'Done'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM'
+        $content = [System.IO.File]::ReadAllText($testFile, $utf8NoBom)
+
+        # Assert
+        $content | Should -Be "Line Done`r`nNext Done`r`n"
+    }
+
+    It 'Appends a trailing newline using the existing LF line ending style' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'append-existing-lf-newline.txt'
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($testFile, "Line {{VAR}}`nNext {{VAR}}", $utf8NoBom)
+
+        $env:VAR = 'Done'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM'
+        $content = [System.IO.File]::ReadAllText($testFile, $utf8NoBom)
+
+        # Assert
+        $content | Should -Be "Line Done`nNext Done`n"
+    }
+
+    It 'Falls back to the environment newline when the file has no existing line endings' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'append-environment-newline.txt'
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($testFile, 'Line {{VAR}}', $utf8NoBom)
+
+        $env:VAR = 'Done'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM'
+        $content = [System.IO.File]::ReadAllText($testFile, $utf8NoBom)
+        $expected = 'Line Done' + [Environment]::NewLine
+
+        # Assert
+        $content | Should -Be $expected
+    }
+
     It 'Invoke-ReplaceTokens fails when fail-on-skipped is enabled and tokens are unresolved' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'fail-on-skipped.txt'

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,8 @@ inputs:
     description: >-
       Do not append a trailing newline to the file.
       By default, an existing trailing newline is preserved and a newline is
-      appended only when the file does not already end with one.
+      appended only when the file does not already end with one, using the
+      file's detected line ending style when possible.
     required: false
     default: 'false'
 


### PR DESCRIPTION
## Summary

- detect the existing newline style from the file content before writing
- reuse that newline style when appending a trailing newline
- fall back to the environment newline when the file has no detectable line endings
- add tests for CRLF, LF, and fallback behavior