### PR TITLE
feat: add opt-in case-insensitive environment variable matching

### DIFF
--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -33,6 +33,9 @@ function Expand-TemplateFile
     .PARAMETER NoNewline
         Do not append a newline at the end of the file when writing changes.
 
+    .PARAMETER CaseInsensitive
+        Match environment variable names without regard to case on all platforms.
+
     .PARAMETER Exclude
         Specify files or directories to exclude from processing.
 
@@ -99,6 +102,10 @@ function Expand-TemplateFile
         [Parameter(HelpMessage = 'Do not append a newline at the end of the file when writing changes')]
         [switch]
         $NoNewline,
+
+        [Parameter(HelpMessage = 'Match environment variable names without regard to case on all platforms')]
+        [switch]
+        $CaseInsensitive,
 
         [Parameter(HelpMessage = 'Specify files or directories to exclude')]
         [string[]]
@@ -803,7 +810,7 @@ function Expand-TemplateFile
 
         # Cache environment variables for better performance
         # Avoid repeated Test-Path and Get-Item calls
-        $envComparer = if (Test-IsWindows)
+        $envComparer = if ($CaseInsensitive -or (Test-IsWindows))
         {
             [System.StringComparer]::OrdinalIgnoreCase
         }

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -57,6 +57,10 @@
         or more tokens are skipped because a matching environment variable was not
         available or its value was empty.
 
+    .PARAMETER CaseInsensitive
+        A string boolean value that enables case-insensitive environment variable
+        name matching on all platforms.
+
     .PARAMETER VerboseInput
         A string boolean value that enables verbose output from
         Expand-TemplateFile.ps1.
@@ -99,6 +103,12 @@
 
         Fails the command if any token is left unresolved because a matching
         environment variable is missing or empty.
+
+    .EXAMPLE
+        ./Invoke-ReplaceTokens.ps1 -PathsInput './template.txt' -CaseInsensitive true
+
+        Enables case-insensitive environment variable name matching even on
+        Linux and macOS runners.
 #>
 param(
     [string]
@@ -136,6 +146,9 @@ param(
 
     [string]
     $FailOnSkipped = 'false',
+
+    [string]
+    $CaseInsensitive = 'false',
 
     [string]
     $VerboseInput = 'false'
@@ -188,6 +201,7 @@ $exclude = Split-MultilineInput -Value $ExcludeInput
 $dryRunEnabled = [System.Convert]::ToBoolean($DryRun)
 $failEnabled = [System.Convert]::ToBoolean($Fail)
 $failOnSkippedEnabled = [System.Convert]::ToBoolean($FailOnSkipped)
+$caseInsensitiveEnabled = [System.Convert]::ToBoolean($CaseInsensitive)
 
 $params = @{
     Path = $paths
@@ -198,6 +212,11 @@ $params = @{
     Encoding = $Encoding
     NoNewline = [System.Convert]::ToBoolean($NoNewline)
     Verbose = [System.Convert]::ToBoolean($VerboseInput)
+}
+
+if ($caseInsensitiveEnabled)
+{
+    $params.CaseInsensitive = $true
 }
 
 if (-not [string]::IsNullOrWhiteSpace($Filter))

--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@
 
 See [action.yml](action.yml).
 
-| name              | description                      | type    | required | default    | example       |
-| ----------------- | -------------------------------- | ------- | -------- | ---------- | ------------- |
-| `paths`           | File paths to process [^1]       | string  | false    | `.`        | `./prod.json` |
-| `style`           | [Token style](#token-style)      | string  | false    | `mustache` | `envsubst`    |
-| `filter`          | Filename filter [^2]             | string  | false    | none       | `*.json`      |
-| `exclude`         | Exclude patterns [^3]            | string  | false    | none       | `*dev*.json`  |
-| `recurse`         | Search subdirectories            | boolean | false    | `false`    | `true`        |
-| `depth`           | Recursion depth (`0` = no limit) | number  | false    | `0`        | `2`           |
-| `follow-symlinks` | Follow symbolic links            | boolean | false    | `false`    | `true`        |
-| `dry-run`         | Preview without modifying files  | boolean | false    | `false`    | `true`        |
-| `fail`            | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
-| `fail-on-skipped` | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
-| `case-insensitive` | Ignore environment variable name casing | boolean | false | `false` | `true` |
-| `encoding`        | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
-| `no-newline`      | Skip the final newline           | boolean | false    | `false`    | `true`        |
-| `verbose`         | Enable verbose logging           | boolean | false    | `false`    | `true`        |
+| name               | description                             | type    | required | default    | example       |
+| ------------------ | --------------------------------------- | ------- | -------- | ---------- | ------------- |
+| `paths`            | File paths to process [^1]              | string  | false    | `.`        | `./prod.json` |
+| `style`            | [Token style](#token-style)             | string  | false    | `mustache` | `envsubst`    |
+| `filter`           | Filename filter [^2]                    | string  | false    | none       | `*.json`      |
+| `exclude`          | Exclude patterns [^3]                   | string  | false    | none       | `*dev*.json`  |
+| `recurse`          | Search subdirectories                   | boolean | false    | `false`    | `true`        |
+| `depth`            | Recursion depth (`0` = no limit)        | number  | false    | `0`        | `2`           |
+| `follow-symlinks`  | Follow symbolic links                   | boolean | false    | `false`    | `true`        |
+| `dry-run`          | Preview without modifying files         | boolean | false    | `false`    | `true`        |
+| `fail`             | Fail if nothing changes [^4]            | boolean | false    | `false`    | `true`        |
+| `fail-on-skipped`  | Fail if any token is unresolved         | boolean | false    | `false`    | `true`        |
+| `case-insensitive` | Ignore environment variable name casing | boolean | false    | `false`    | `true`        |
+| `encoding`         | [File encoding](#file-encoding)         | string  | false    | `auto`     | `unicode`     |
+| `no-newline`       | Skip the final newline                  | boolean | false    | `false`    | `true`        |
+| `verbose`          | Enable verbose logging                  | boolean | false    | `false`    | `true`        |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Replace tokens in a file](#replace-tokens-in-a-file)
   - [Using a path filter](#using-a-path-filter)
   - [Search multiple paths](#search-multiple-paths)
+  - [Case-insensitive environment variable matching](#case-insensitive-environment-variable-matching)
   - [Replace other token styles](#replace-other-token-styles)
   - [Search paths recursively](#search-paths-recursively)
   - [Replace an API key and URL in .env files](#replace-an-api-key-and-url-in-env-files)
@@ -43,6 +44,7 @@ See [action.yml](action.yml).
 | `dry-run`         | Preview without modifying files  | boolean | false    | `false`    | `true`        |
 | `fail`            | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
 | `fail-on-skipped` | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
+| `case-insensitive` | Ignore environment variable name casing | boolean | false | `false` | `true` |
 | `encoding`        | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
 | `no-newline`      | Skip the final newline           | boolean | false    | `false`    | `true`        |
 | `verbose`         | Enable verbose logging           | boolean | false    | `false`    | `true`        |
@@ -58,7 +60,8 @@ See [action.yml](action.yml).
 
 - GitHub-hosted runners execute the composite action with PowerShell Core (`pwsh`).
 - On self-hosted Windows runners, GitHub Actions falls back to Windows PowerShell when `pwsh` is not installed, so the action remains usable in both environments.
-- Environment variable name matching follows platform conventions: case-insensitive on Windows, case-sensitive on Linux and macOS.
+- Environment variable name matching follows platform conventions by default: case-insensitive on Windows, case-sensitive on Linux and macOS.
+- Set `case-insensitive: true` to use case-insensitive environment variable name matching on any runner.
 - The `Expand-TemplateFile.ps1` script remains compatible with Windows PowerShell 5.1 and PowerShell Core 6+ for self-hosted fallback and direct script usage.
 
 ## Examples
@@ -79,7 +82,22 @@ steps:
 ```
 
 > [!NOTE]  
-> Environment variable names are matched case-insensitively on Windows, and case-sensitively on Linux and macOS.
+> Environment variable names are matched case-insensitively on Windows, and case-sensitively on Linux and macOS by default. Set `case-insensitive: true` to opt into case-insensitive matching everywhere.
+
+### Case-insensitive environment variable matching
+
+Use `case-insensitive: true` when token casing does not need to match the environment variable name exactly.
+
+```yaml
+steps:
+  - name: Replace tokens with case-insensitive environment variable matching
+    uses: jonlabelle/replace-tokens-action@v1
+    with:
+      paths: ./path/to/template.json
+      case-insensitive: true
+    env:
+      NAME: jon
+```
 
 ### Using a path filter
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@
 
 See [action.yml](action.yml).
 
-| name               | description                             | type    | required | default    | example       |
-| ------------------ | --------------------------------------- | ------- | -------- | ---------- | ------------- |
-| `paths`            | File paths to process [^1]              | string  | false    | `.`        | `./prod.json` |
-| `style`            | [Token style](#token-style)             | string  | false    | `mustache` | `envsubst`    |
-| `filter`           | Filename filter [^2]                    | string  | false    | none       | `*.json`      |
-| `exclude`          | Exclude patterns [^3]                   | string  | false    | none       | `*dev*.json`  |
-| `recurse`          | Search subdirectories                   | boolean | false    | `false`    | `true`        |
-| `depth`            | Recursion depth (`0` = no limit)        | number  | false    | `0`        | `2`           |
-| `follow-symlinks`  | Follow symbolic links                   | boolean | false    | `false`    | `true`        |
-| `dry-run`          | Preview without modifying files         | boolean | false    | `false`    | `true`        |
-| `fail`             | Fail if nothing changes [^4]            | boolean | false    | `false`    | `true`        |
-| `fail-on-skipped`  | Fail if any token is unresolved         | boolean | false    | `false`    | `true`        |
-| `case-insensitive` | Ignore environment variable name casing | boolean | false    | `false`    | `true`        |
-| `encoding`         | [File encoding](#file-encoding)         | string  | false    | `auto`     | `unicode`     |
-| `no-newline`       | Skip the final newline                  | boolean | false    | `false`    | `true`        |
-| `verbose`          | Enable verbose logging                  | boolean | false    | `false`    | `true`        |
+| name               | description                      | type    | required | default    | example       |
+| ------------------ | -------------------------------- | ------- | -------- | ---------- | ------------- |
+| `paths`            | File paths to process [^1]       | string  | false    | `.`        | `./prod.json` |
+| `style`            | [Token style](#token-style)      | string  | false    | `mustache` | `envsubst`    |
+| `filter`           | Filename filter [^2]             | string  | false    | none       | `*.json`      |
+| `exclude`          | Exclude patterns [^3]            | string  | false    | none       | `*dev*.json`  |
+| `recurse`          | Search subdirectories            | boolean | false    | `false`    | `true`        |
+| `depth`            | Recursion depth (`0` = no limit) | number  | false    | `0`        | `2`           |
+| `follow-symlinks`  | Follow symbolic links            | boolean | false    | `false`    | `true`        |
+| `dry-run`          | Preview without modifying files  | boolean | false    | `false`    | `true`        |
+| `fail`             | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
+| `fail-on-skipped`  | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
+| `case-insensitive` | Ignore env variable casing       | boolean | false    | `false`    | `true`        |
+| `encoding`         | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
+| `no-newline`       | Skip the final newline           | boolean | false    | `false`    | `true`        |
+| `verbose`          | Enable verbose logging           | boolean | false    | `false`    | `true`        |
 
 ## Outputs
 

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -703,7 +703,7 @@ Describe 'Expand-TemplateFile Function' {
         $result[0].Modified | Should -Be $false
     }
 
-    It 'Uses platform-appropriate case sensitivity for environment variable names' {
+    It 'Uses platform-appropriate case sensitivity for environment variable names by default' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'case-sensitive-env-var.txt'
         Write-Utf8Content -Path $testFile -Value 'Case {{name}} test' -NoNewline
@@ -727,6 +727,23 @@ Describe 'Expand-TemplateFile Function' {
             $result[0].TokensReplaced | Should -Be 0
             $result[0].Modified | Should -Be $false
         }
+    }
+
+    It 'Supports opt-in case-insensitive environment variable matching on all platforms' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'case-insensitive-env-var.txt'
+        Write-Utf8Content -Path $testFile -Value 'Case {{name}} test' -NoNewline
+
+        $env:NAME = 'CaseValue'
+
+        # Act
+        $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline -CaseInsensitive
+        $content = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $content | Should -Be 'Case CaseValue test'
+        $result[0].TokensReplaced | Should -Be 1
+        $result[0].Modified | Should -Be $true
     }
 
     It 'Preserves an existing trailing newline without appending a duplicate newline' {
@@ -837,6 +854,52 @@ Describe 'Expand-TemplateFile Function' {
         $actionOutput = Get-Content -Path $outputFile -Raw
         $actionOutput | Should -Match 'tokens-skipped=1'
         $actionOutput | Should -Match 'tokens-replaced=1'
+    }
+
+    It 'Invoke-ReplaceTokens supports case-insensitive matching when enabled' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'invoke-case-insensitive.txt'
+        $outputFile = Join-Path -Path $testDir -ChildPath 'invoke-case-insensitive-output.txt'
+        $scriptPath = Join-Path -Path (Get-Item -Path $PSScriptRoot).Parent.FullName -ChildPath 'Invoke-ReplaceTokens.ps1'
+        $powershellPath = Get-CurrentPowerShellPath
+        Write-Utf8Content -Path $testFile -Value 'Hello {{name}}' -NoNewline
+
+        $env:NAME = 'Avery'
+
+        if (Test-Path -Path $outputFile)
+        {
+            Remove-Item -Path $outputFile -Force
+        }
+
+        $previousGithubOutput = $env:GITHUB_OUTPUT
+        $env:GITHUB_OUTPUT = $outputFile
+
+        try
+        {
+            $commandOutput = & $powershellPath -NoProfile -File $scriptPath -PathsInput $testFile -Style 'mustache' -NoNewline 'true' -CaseInsensitive 'true' 2>&1 | Out-String
+            $exitCode = $LASTEXITCODE
+        }
+        finally
+        {
+            if ([string]::IsNullOrWhiteSpace($previousGithubOutput))
+            {
+                Remove-Item Env:GITHUB_OUTPUT -ErrorAction SilentlyContinue
+            }
+            else
+            {
+                $env:GITHUB_OUTPUT = $previousGithubOutput
+            }
+        }
+
+        # Assert
+        $exitCode | Should -Be 0
+        $commandOutput | Should -Match 'Replaced: 1, Skipped: 0'
+        (Get-Content -Path $testFile -Raw) | Should -Be 'Hello Avery'
+
+        $actionOutput = Get-Content -Path $outputFile -Raw
+        $actionOutput | Should -Match 'tokens-replaced=1'
+        $actionOutput | Should -Match 'tokens-skipped=0'
+        $actionOutput | Should -Match 'modified-files-count=1'
     }
 
     It 'Throws error when -Depth is used without -Recurse' {

--- a/action.yml
+++ b/action.yml
@@ -100,6 +100,13 @@ inputs:
     required: false
     default: 'false'
 
+  case-insensitive:
+    description: >-
+      Match environment variable names without regard to case on all platforms.
+      Defaults to `false`, which preserves the platform default behavior.
+    required: false
+    default: 'false'
+
   verbose:
     description: >-
       Enable verbose output.
@@ -158,4 +165,5 @@ runs:
           -DryRun '${{ inputs.dry-run }}' `
           -Fail '${{ inputs.fail }}' `
           -FailOnSkipped '${{ inputs.fail-on-skipped }}' `
+          -CaseInsensitive '${{ inputs.case-insensitive }}' `
           -VerboseInput '${{ inputs.verbose }}'


### PR DESCRIPTION
## Summary

Adds a new opt-in `case-insensitive` option for environment variable name matching.

By default, the action keeps its existing platform-specific behavior:

- Windows remains case-insensitive
- Linux and macOS remain case-sensitive

When `case-insensitive: true` is enabled, all platforms use case-insensitive environment variable matching.

## Changes

- add a `CaseInsensitive` switch to `Expand-TemplateFile.ps1`
- add a `case-insensitive` action input in `action.yml`
- pass the new input through `Invoke-ReplaceTokens.ps1`
- update environment variable lookup to use case-insensitive matching when explicitly enabled
- update README usage and platform behavior documentation
- add tests for:
  - default platform-specific case matching
  - opt-in case-insensitive matching in `Expand-TemplateFile`
  - opt-in case-insensitive matching through `Invoke-ReplaceTokens`