### PR TITLE
feat: add underscores token style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+### Features
+
+* add underscores token style support
+
 # [1.37.0](https://github.com/jonlabelle/replace-tokens-action/compare/v1.36.0...v1.37.0) (2026-03-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-# Unreleased
-
-### Features
-
-* add underscores token style support
-
 # [1.37.0](https://github.com/jonlabelle/replace-tokens-action/compare/v1.36.0...v1.37.0) (2026-03-20)
 
 

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -6,13 +6,13 @@ function Expand-TemplateFile
 
     .DESCRIPTION
         Expands template files by replacing tokens with values from environment variables.
-        Supports multiple token styles: mustache/handlebars ({{VAR}}), brackets (<VAR>), hashes (##VAR##), envsubst (${VAR}), and make ($(VAR)).
+        Supports multiple token styles: mustache/handlebars ({{VAR}}), brackets (<VAR>), hashes (##VAR##), underscores (__VAR__), envsubst (${VAR}), and make ($(VAR)).
 
     .PARAMETER Path
         Specify the path(s) to process. Can be files or directories.
 
     .PARAMETER Style
-        Specify the token style to use. Valid values: mustache, handlebars, brackets, hashes, envsubst, make.
+        Specify the token style to use. Valid values: mustache, handlebars, brackets, hashes, underscores, envsubst, make.
         Default: mustache
 
     .PARAMETER Filter
@@ -74,7 +74,7 @@ function Expand-TemplateFile
         $Path,
 
         [Parameter(HelpMessage = 'Specify the token style to use')]
-        [ValidateSet('mustache', 'handlebars', 'brackets', 'hashes', 'double-hashes', 'envsubst', 'make', IgnoreCase = $true)]
+        [ValidateSet('mustache', 'handlebars', 'brackets', 'hashes', 'double-hashes', 'underscores', 'envsubst', 'make', IgnoreCase = $true)]
         [string]
         $Style = 'mustache',
 
@@ -790,6 +790,7 @@ function Expand-TemplateFile
         $mustachePattern = '\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}' # handlebars/mustache pattern, e.g. {{VARIABLE}}
         $bracketsPattern = '<\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*>' # brackets pattern, e.g. <VARIABLE>; NOTE: avoid using on HTML/XML files as this pattern matches tag names
         $hashesPattern = '##\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*##' # hashes pattern, e.g. ##VARIABLE##
+        $underscoresPattern = '__\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*__' # underscores pattern, e.g. __VARIABLE__
         $envsubstPattern = '\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}' # envsubst template pattern, e.g. ${VARIABLE}
         $makePattern = '\$\(([a-zA-Z_][a-zA-Z0-9_]*)\)' # make pattern, e.g. $(VARIABLE)
 
@@ -801,6 +802,7 @@ function Expand-TemplateFile
             'brackets' { $bracketsPattern }
             'hashes' { $hashesPattern }
             'double-hashes' { $hashesPattern }
+            'underscores' { $underscoresPattern }
             'envsubst' { $envsubstPattern }
             'make' { $makePattern }
             default { throw "Unknown token style: $Style" }

--- a/Invoke-ReplaceTokens.ps1
+++ b/Invoke-ReplaceTokens.ps1
@@ -17,7 +17,7 @@
 
     .PARAMETER Style
         The token style to replace. Valid values are mustache, handlebars,
-        brackets, hashes, envsubst, and make.
+        brackets, hashes, underscores, envsubst, and make.
 
     .PARAMETER Filter
         An optional Get-ChildItem filter used to limit matching files.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ steps:
       NAME: jon
 ```
 
+Replace tokens using the **underscores** style, for example `__VARIABLE__`.
+
+```yaml
+steps:
+  - name: Replace underscore styled tokens
+    uses: jonlabelle/replace-tokens-action@v1
+    with:
+      paths: ./path/to/search
+      filter: '*.json'
+      style: underscores
+    env:
+      NAME: jon
+```
+
 Replace tokens using the **make** style, for example `$(VARIABLE)`.
 
 ```yaml
@@ -364,6 +378,7 @@ Use one of the following token formats:
 | `handlebars`         | `{{ VARIABLE }}` | `{{TOKEN}}`, `{{ TOKEN }}` |
 | `brackets`           | `< VARIABLE >`   | `<TOKEN>`, `< TOKEN >`     |
 | `hashes`             | `## VARIABLE ##` | `##TOKEN##`, `## TOKEN ##` |
+| `underscores`        | `__ VARIABLE __` | `__TOKEN__`, `__ TOKEN __` |
 | `envsubst`           | `${VARIABLE}`    | `${TOKEN}`                 |
 | `make`               | `$(VARIABLE)`    | `$(TOKEN)`                 |
 

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -370,6 +370,21 @@ Describe 'Expand-TemplateFile Function' {
         $result | Should -Be 'Hello, Bailey!'
     }
 
+    It 'Replaces tokens with underscores style' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'underscores-style-basic.txt'
+        Write-Utf8Content -Path $testFile -Value 'Hello, __NAME__!' -NoNewline
+
+        $env:NAME = 'Parker'
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'underscores' -Encoding 'utf8NoBOM' -NoNewline
+        $result = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $result | Should -Be 'Hello, Parker!'
+    }
+
     It 'Accepts the hashes token format with the alternate style value' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'hashes-alternate-style-basic.txt'
@@ -503,6 +518,22 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $result | Should -Be 'Valid: HashValue - Invalid: ##123VAR##'
+    }
+
+    It 'Correctly handles underscores style with valid/invalid variable names' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'underscores-style.txt'
+        Write-Utf8Content -Path $testFile -Value 'Valid: __ HASH_VAR __ - Invalid: __123VAR__' -NoNewline
+
+        $env:HASH_VAR = 'HashValue'
+        $env:123VAR = 'Invalid'  # Won't be matched - token variable names must start with a letter or underscore
+
+        # Act
+        Expand-TemplateFile -Path $testFile -Style 'underscores' -Encoding 'utf8NoBOM' -NoNewline
+        $result = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $result | Should -Be 'Valid: HashValue - Invalid: __123VAR__'
     }
 
     It 'Correctly handles brackets style with valid/invalid variable names' {
@@ -837,6 +868,25 @@ Describe 'Expand-TemplateFile Function' {
 
         # Act
         $commandOutput = & $powershellPath -NoProfile -File $scriptPath -PathsInput $testFile -Style 'hashes' -Encoding 'utf8NoBOM' -NoNewline 'true' 2>&1 | Out-String
+        $exitCode = $LASTEXITCODE
+
+        # Assert
+        $exitCode | Should -Be 0
+        $commandOutput | Should -Match 'Replaced: 1, Skipped: 0'
+        (Get-Content -Path $testFile -Raw) | Should -Be 'Hello Avery'
+    }
+
+    It 'Invoke-ReplaceTokens supports underscores style' {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'invoke-underscores-style.txt'
+        $scriptPath = Join-Path -Path (Get-Item -Path $PSScriptRoot).Parent.FullName -ChildPath 'Invoke-ReplaceTokens.ps1'
+        $powershellPath = Get-CurrentPowerShellPath
+        Write-Utf8Content -Path $testFile -Value 'Hello __NAME__' -NoNewline
+
+        $env:NAME = 'Avery'
+
+        # Act
+        $commandOutput = & $powershellPath -NoProfile -File $scriptPath -PathsInput $testFile -Style 'underscores' -Encoding 'utf8NoBOM' -NoNewline 'true' 2>&1 | Out-String
         $exitCode = $LASTEXITCODE
 
         # Assert

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   style:
     description: >-
       Token style to replace.
-      Accepted values are `mustache` (for example, `{{ VARIABLE }}`), `handlebars` (for example, `{{ VARIABLE }}`), `brackets` (for example, `< VARIABLE >`), `hashes` (for example, `## VARIABLE ##`), `envsubst` (for example, `${VARIABLE}`), and `make` (for example, `$(VARIABLE)`).
+      Accepted values are `mustache` (for example, `{{ VARIABLE }}`), `handlebars` (for example, `{{ VARIABLE }}`), `brackets` (for example, `< VARIABLE >`), `hashes` (for example, `## VARIABLE ##`), `underscores` (for example, `__ VARIABLE __`), `envsubst` (for example, `${VARIABLE}`), and `make` (for example, `$(VARIABLE)`).
       Defaults to `mustache`.
     required: false
     default: 'mustache'


### PR DESCRIPTION
## Summary
- add the underscores token style using __TOKEN__ delimiters
- add Pester coverage for direct and Invoke-ReplaceTokens usage
- update action metadata, README, and changelog

## Testing
- pwsh -NoProfile -File Tests/Expand-TemplateFile.Tests.ps1