### PR TITLE
test: expand stub edge-case coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,7 @@ jobs:
           verbose: true
         env:
           NAME: jon
+          _NAME: shadow
 
       - name: Show actual result for ${{ matrix.style }} test on ${{ matrix.os }}
         run: cat "${{ steps.test-setup.outputs.subject-path }}"
@@ -184,6 +185,7 @@ jobs:
           no-newline: true
         env:
           NAME: jon
+          _NAME: shadow
 
       - name: Assert dry-run file is unchanged on ${{ matrix.os }}
         run: |
@@ -209,8 +211,8 @@ jobs:
             exit 1
           }
 
-          if ('${{ steps.dry-run-action.outputs.tokens-replaced }}' -ne '5') {
-            Write-Host '::error title=FAIL Dry-run replacement count mismatch::Expected tokens-replaced to be 5.'
+          if ('${{ steps.dry-run-action.outputs.tokens-replaced }}' -ne '6') {
+            Write-Host '::error title=FAIL Dry-run replacement count mismatch::Expected tokens-replaced to be 6.'
             exit 1
           }
 

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -787,9 +787,9 @@ function Expand-TemplateFile
         $script:tokensSkipped = 0
 
         # Define token patterns with validation for environment variable names
-        $mustachePattern = '\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}' # handlebars/mustache pattern, e.g. {{VARIABLE}}
-        $bracketsPattern = '<\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*>' # brackets pattern, e.g. <VARIABLE>; NOTE: avoid using on HTML/XML files as this pattern matches tag names
-        $hashesPattern = '##\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*##' # hashes pattern, e.g. ##VARIABLE##
+        $mustachePattern = '\{\{[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*\}\}' # handlebars/mustache pattern, e.g. {{VARIABLE}}; allow horizontal whitespace, but not newlines
+        $bracketsPattern = '<[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*>' # brackets pattern, e.g. <VARIABLE>; NOTE: avoid using on HTML/XML files as this pattern matches tag names
+        $hashesPattern = '##[ \t]*([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*##' # hashes pattern, e.g. ##VARIABLE##; allow horizontal whitespace, but not newlines
         $underscoresPattern = '__[ \t]*([a-zA-Z_][a-zA-Z0-9_]*?)[ \t]*__' # underscores pattern, e.g. __VARIABLE__; keep matches on one line and stop before the closing delimiter
         $envsubstPattern = '\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}' # envsubst template pattern, e.g. ${VARIABLE}
         $makePattern = '\$\(([a-zA-Z_][a-zA-Z0-9_]*)\)' # make pattern, e.g. $(VARIABLE)

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -434,6 +434,56 @@ Describe 'Expand-TemplateFile Function' {
         $result | Should -Be 'Hello, Charlie!'
     }
 
+    It 'Stub fixtures cover edge-case replacements for every supported style' {
+        # Arrange
+        $styles = @('mustache', 'handlebars', 'brackets', 'hashes', 'underscores', 'envsubst', 'make')
+        $stubsDir = Join-Path -Path $PSScriptRoot -ChildPath 'stubs'
+        $expectedPath = Join-Path -Path (Join-Path -Path $stubsDir -ChildPath 'expected') -ChildPath 'replaced.tpl'
+        $untouchedFixture = Join-Path -Path (Join-Path -Path $stubsDir -ChildPath 'untouched') -ChildPath 'no-matches.tpl'
+        $expectedContent = Get-Content -Path $expectedPath -Raw
+        $originalName = if (Test-Path Env:NAME) { $env:NAME } else { $null }
+        $originalUnderscoreName = if (Test-Path Env:_NAME) { $env:_NAME } else { $null }
+
+        try {
+            $env:NAME = 'jon'
+            $env:_NAME = 'shadow'
+
+            foreach ($style in $styles) {
+                $subject = Join-Path -Path $testDir -ChildPath "stub-$style.tpl"
+                $untouched = Join-Path -Path $testDir -ChildPath "stub-$style-untouched.tpl"
+                $pristine = Join-Path -Path (Join-Path -Path $stubsDir -ChildPath 'pristine') -ChildPath "$style.tpl"
+
+                Copy-Item -Path $pristine -Destination $subject -Force
+                Copy-Item -Path $untouchedFixture -Destination $untouched -Force
+
+                $untouchedHash = (Get-FileHash -Path $untouched -Algorithm SHA256).Hash
+                $fileResults = Expand-TemplateFile -Path $subject, $untouched -Style $style -Encoding 'auto' -NoNewline -WarningAction SilentlyContinue
+                $subjectResult = $fileResults | Where-Object { $_.FilePath -eq $subject }
+                $untouchedResult = $fileResults | Where-Object { $_.FilePath -eq $untouched }
+
+                (Get-Content -Path $subject -Raw) | Should -Be $expectedContent
+                (Get-FileHash -Path $untouched -Algorithm SHA256).Hash | Should -Be $untouchedHash
+                $subjectResult.TokensReplaced | Should -Be 6
+                $subjectResult.TokensSkipped | Should -Be 0
+                $subjectResult.Modified | Should -BeTrue
+                $untouchedResult.TokensReplaced | Should -Be 0
+                $untouchedResult.Modified | Should -BeFalse
+            }
+        } finally {
+            if ($null -eq $originalName) {
+                Remove-Item Env:NAME -ErrorAction SilentlyContinue
+            } else {
+                $env:NAME = $originalName
+            }
+
+            if ($null -eq $originalUnderscoreName) {
+                Remove-Item Env:_NAME -ErrorAction SilentlyContinue
+            } else {
+                $env:_NAME = $originalUnderscoreName
+            }
+        }
+    }
+
     It 'Does not replace tokens if file is excluded' {
         # Arrange
         $testFile = Join-Path -Path $testDir -ChildPath 'excluded-file.txt'

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -444,11 +444,13 @@ Describe 'Expand-TemplateFile Function' {
         $originalName = if (Test-Path Env:NAME) { $env:NAME } else { $null }
         $originalUnderscoreName = if (Test-Path Env:_NAME) { $env:_NAME } else { $null }
 
-        try {
+        try
+        {
             $env:NAME = 'jon'
             $env:_NAME = 'shadow'
 
-            foreach ($style in $styles) {
+            foreach ($style in $styles)
+            {
                 $subject = Join-Path -Path $testDir -ChildPath "stub-$style.tpl"
                 $untouched = Join-Path -Path $testDir -ChildPath "stub-$style-untouched.tpl"
                 $pristine = Join-Path -Path (Join-Path -Path $stubsDir -ChildPath 'pristine') -ChildPath "$style.tpl"
@@ -469,16 +471,24 @@ Describe 'Expand-TemplateFile Function' {
                 $untouchedResult.TokensReplaced | Should -Be 0
                 $untouchedResult.Modified | Should -BeFalse
             }
-        } finally {
-            if ($null -eq $originalName) {
+        }
+        finally
+        {
+            if ($null -eq $originalName)
+            {
                 Remove-Item Env:NAME -ErrorAction SilentlyContinue
-            } else {
+            }
+            else
+            {
                 $env:NAME = $originalName
             }
 
-            if ($null -eq $originalUnderscoreName) {
+            if ($null -eq $originalUnderscoreName)
+            {
                 Remove-Item Env:_NAME -ErrorAction SilentlyContinue
-            } else {
+            }
+            else
+            {
                 $env:_NAME = $originalUnderscoreName
             }
         }

--- a/Tests/stubs/expected/replaced.tpl
+++ b/Tests/stubs/expected/replaced.tpl
@@ -1,5 +1,5 @@
 jon
     jon
         jon
-    jon
-jon
+    shadow
+jonjon

--- a/Tests/stubs/pristine/brackets.tpl
+++ b/Tests/stubs/pristine/brackets.tpl
@@ -1,5 +1,5 @@
 < NAME >
     <NAME>
-        <NAME>
-    <NAME>
-< NAME >
+        <	NAME	>
+    < _NAME >
+<NAME><NAME>

--- a/Tests/stubs/pristine/envsubst.tpl
+++ b/Tests/stubs/pristine/envsubst.tpl
@@ -1,5 +1,5 @@
 ${NAME}
     ${NAME}
         ${NAME}
-    ${NAME}
-${NAME}
+    ${_NAME}
+${NAME}${NAME}

--- a/Tests/stubs/pristine/handlebars.tpl
+++ b/Tests/stubs/pristine/handlebars.tpl
@@ -1,5 +1,5 @@
 {{ NAME }}
     {{NAME}}
-        {{NAME}}
-    {{NAME}}
-{{ NAME }}
+        {{	NAME	}}
+    {{ _NAME }}
+{{NAME}}{{NAME}}

--- a/Tests/stubs/pristine/hashes.tpl
+++ b/Tests/stubs/pristine/hashes.tpl
@@ -1,5 +1,5 @@
 ## NAME ##
     ##NAME##
-        ##NAME##
-    ##NAME##
-## NAME ##
+        ##	NAME	##
+    ## _NAME ##
+##NAME####NAME##

--- a/Tests/stubs/pristine/make.tpl
+++ b/Tests/stubs/pristine/make.tpl
@@ -1,5 +1,5 @@
 $(NAME)
     $(NAME)
         $(NAME)
-    $(NAME)
-$(NAME)
+    $(_NAME)
+$(NAME)$(NAME)

--- a/Tests/stubs/pristine/mustache.tpl
+++ b/Tests/stubs/pristine/mustache.tpl
@@ -1,5 +1,5 @@
 {{ NAME }}
     {{NAME}}
-        {{NAME}}
-    {{NAME}}
-{{ NAME }}
+        {{	NAME	}}
+    {{ _NAME }}
+{{NAME}}{{NAME}}

--- a/Tests/stubs/pristine/underscores.tpl
+++ b/Tests/stubs/pristine/underscores.tpl
@@ -1,5 +1,5 @@
 __ NAME __
     __NAME__
-        __NAME__
-    __NAME__
-__ NAME __
+        __	NAME	__
+    __ _NAME __
+__NAME____NAME__

--- a/Tests/stubs/untouched/no-matches.tpl
+++ b/Tests/stubs/untouched/no-matches.tpl
@@ -8,14 +8,34 @@ NAME}
 {NAME}}
 {{NAME}
 {NAME}
-{{ _NAME }}
+{{ __NAME }}
 {{ my.NAME.is.mud }}
+{{ 123NAME }}
+{{
+NAME
+}}
+<123NAME>
+<
+NAME
+>
+##123NAME##
+##
+NAME
+##
+__123NAME__
+__
+NAME
+__
 ${I_DO_NOT_EXIST_I63ERM}
+${123NAME}
 {{ I_DO_NOT_EXIST_I63ERM }}
+## I_DO_NOT_EXIST_I63ERM ##
+__ I_DO_NOT_EXIST_I63ERM __
 $(NAME}
 ${NAME)
-$(_NAME)
+$(__NAME)
 $(NAME
 $( NAME )
 $(NAME )
 $( NAME)
+$(123NAME)

--- a/Tests/stubs/untouched/no-matches.tpl
+++ b/Tests/stubs/untouched/no-matches.tpl
@@ -8,7 +8,7 @@ NAME}
 {NAME}}
 {{NAME}
 {NAME}
-{{ __NAME }}
+{{ I_DO_NOT_EXIST_STUB_E98AF1 }}
 {{ my.NAME.is.mud }}
 {{ 123NAME }}
 {{
@@ -33,7 +33,7 @@ ${123NAME}
 __ I_DO_NOT_EXIST_I63ERM __
 $(NAME}
 ${NAME)
-$(__NAME)
+$(I_DO_NOT_EXIST_STUB_E98AF1)
 $(NAME
 $( NAME )
 $(NAME )


### PR DESCRIPTION
This pull request introduces improvements to the template expansion logic and its test coverage. The main changes include updating token patterns to handle whitespace more robustly, expanding test coverage to ensure all supported styles are tested for edge cases, and updating fixtures and workflow assertions to reflect these enhancements.

**Template Expansion Improvements:**

* Updated token patterns in `Expand-TemplateFile.ps1` to allow horizontal whitespace (spaces and tabs) but not newlines for mustache, brackets, and hashes styles, making token matching more robust and consistent.

**Test Coverage Enhancements:**

* Added a new test in `Expand-TemplateFile.Tests.ps1` to verify edge-case replacements for every supported template style, ensuring all styles handle environment variables and edge cases correctly.