### PR TITLE
feat: add job summaries to CI pipeline

### DIFF
--- a/.github/workflows/_analyze.yml
+++ b/.github/workflows/_analyze.yml
@@ -89,3 +89,18 @@ jobs:
         uses: github/codeql-action/analyze@main
         with:
           category: '/language:${{matrix.language}}'
+
+  summary:
+    name: Analyze summary
+    if: always()
+    needs: [pwsh, codeql]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        run: |
+          echo '### Analysis Results' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
+          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
+          echo "| PSScriptAnalyzer | ${{ needs.pwsh.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CodeQL | ${{ needs.codeql.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_analyze.yml
+++ b/.github/workflows/_analyze.yml
@@ -102,5 +102,5 @@ jobs:
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
           echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| PSScriptAnalyzer | ${{ needs.pwsh.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CodeQL | ${{ needs.codeql.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| PSScriptAnalyzer | ${{ needs.pwsh.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| CodeQL | ${{ needs.codeql.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -61,6 +61,6 @@ jobs:
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
           echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| YAML | ${{ needs.yaml.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Markdown | ${{ needs.markdown.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Prettier | ${{ needs.format.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| YAML | ${{ needs.yaml.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Markdown | ${{ needs.markdown.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Prettier | ${{ needs.format.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -48,3 +48,19 @@ jobs:
 
       - name: Run Prettier format check
         run: npx prettier --check --log-level log '**.{md,yaml,yml,js,json}'
+
+  summary:
+    name: Lint summary
+    if: always()
+    needs: [yaml, markdown, format]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        run: |
+          echo '### Lint Results' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
+          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
+          echo "| YAML | ${{ needs.yaml.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Markdown | ${{ needs.markdown.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Prettier | ${{ needs.format.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -222,5 +222,5 @@ jobs:
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Suite | Status |' >> $GITHUB_STEP_SUMMARY
           echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| Matrix (7 styles x 3 OS x 2 shells) | ${{ needs.test.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dry run (3 OS x 2 shells) | ${{ needs.dry-run.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Matrix (7 styles x 3 OS x 2 shells) | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dry run (3 OS x 2 shells) | ${{ needs.dry-run.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 #
-# Reusable test gate: token replacement matrix (7 styles x 3 OS x 2 shells)
-# and dry-run validation across all platforms.
+# Reusable test gate: token replacement matrix across all styles, platforms,
+# and shells, plus dry-run validation.
 
 name: Test
 
@@ -222,5 +222,5 @@ jobs:
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Suite | Status |' >> $GITHUB_STEP_SUMMARY
           echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| Matrix (7 styles x 3 OS x 2 shells) | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dry run (3 OS x 2 shells) | ${{ needs.dry-run.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Matrix | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dry run | ${{ needs.dry-run.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -209,3 +209,18 @@ jobs:
           }
 
           Write-Host 'PASS: Dry-run outputs are correct'
+
+  summary:
+    name: Test summary
+    if: always()
+    needs: [test, dry-run]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        run: |
+          echo '### Test Results' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Suite | Status |' >> $GITHUB_STEP_SUMMARY
+          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
+          echo "| Matrix (7 styles x 3 OS x 2 shells) | ${{ needs.test.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dry run (3 OS x 2 shells) | ${{ needs.dry-run.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npx semantic-release --ci
+
+  summary:
+    name: CI summary
+    if: always()
+    needs: [lint, analyze, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Write summary
+        run: |
+          echo '## CI Pipeline Summary' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo '| Gate | Status |' >> $GITHUB_STEP_SUMMARY
+          echo '| ---- | ------ |' >> $GITHUB_STEP_SUMMARY
+          echo "| Gate 1: Lint | ${{ needs.lint.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gate 2: Analyze | ${{ needs.analyze.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Gate 3: Test | ${{ needs.test.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
   summary:
     name: CI summary
     if: always()
-    needs: [lint, analyze, test]
+    needs: [lint, analyze, test, release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -107,3 +107,4 @@ jobs:
           echo "| Lint | ${{ needs.lint.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Analyze | ${{ needs.analyze.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Test | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Release | ${{ needs.release.result == 'success' && ':white_check_mark: Pass' || needs.release.result == 'skipped' && ':white_circle: Skipped' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,6 @@ jobs:
           echo '' >> $GITHUB_STEP_SUMMARY
           echo '| Gate | Status |' >> $GITHUB_STEP_SUMMARY
           echo '| ---- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| Gate 1: Lint | ${{ needs.lint.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Gate 2: Analyze | ${{ needs.analyze.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Gate 3: Test | ${{ needs.test.result == 'success' && 'Pass' || 'Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Lint | ${{ needs.lint.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Analyze | ${{ needs.analyze.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Test | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -77,3 +77,15 @@ jobs:
         run: |
           git push origin "${MAJOR_VER}" --force
           echo "::notice title=Main version tagged::Tagged "${TARGET}" with "${MAJOR_VER}""
+
+      - name: Write summary
+        if: ${{ always() }}
+        run: |
+          echo '### Update Main Version' >> $GITHUB_STEP_SUMMARY
+          echo '' >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Target** | \`${{ env.TARGET }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Major version** | \`${{ github.event.inputs.version || '(auto-detected)' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Trigger** | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Status** | ${{ job.status == 'success' && ':white_check_mark: Tagged' || ':x: Failed' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds GitHub Actions job summaries to every stage of the CI pipeline.

Each reusable workflow (`_lint.yml`, `_analyze.yml`, `_test.yml`) now includes a summary job that writes a Markdown results table to `GITHUB_STEP_SUMMARY`. The orchestrator `ci.yml` adds a roll-up summary reporting overall gate status.

## Example output

### CI Pipeline Summary

| Gate | Status |
| ---- | ------ |
| Gate 1: Lint | Pass |
| Gate 2: Analyze | Pass |
| Gate 3: Test | Pass |

Each gate also writes its own detailed breakdown (e.g., Lint shows YAML/Markdown/Prettier individually).
