### PR TITLE
fix: replace workflow summaries with semantic-release output summary

### DIFF
--- a/.github/workflows/_analyze.yml
+++ b/.github/workflows/_analyze.yml
@@ -89,18 +89,3 @@ jobs:
         uses: github/codeql-action/analyze@main
         with:
           category: '/language:${{matrix.language}}'
-
-  summary:
-    name: Analyze summary
-    if: always()
-    needs: [pwsh, codeql]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Write summary
-        run: |
-          echo '### Analysis Results' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
-          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| PSScriptAnalyzer | ${{ needs.pwsh.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| CodeQL | ${{ needs.codeql.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -48,19 +48,3 @@ jobs:
 
       - name: Run Prettier format check
         run: npx prettier --check --log-level log '**.{md,yaml,yml,js,json}'
-
-  summary:
-    name: Lint summary
-    if: always()
-    needs: [yaml, markdown, format]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Write summary
-        run: |
-          echo '### Lint Results' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Check | Status |' >> $GITHUB_STEP_SUMMARY
-          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| YAML | ${{ needs.yaml.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Markdown | ${{ needs.markdown.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Prettier | ${{ needs.format.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -209,18 +209,3 @@ jobs:
           }
 
           Write-Host 'PASS: Dry-run outputs are correct'
-
-  summary:
-    name: Test summary
-    if: always()
-    needs: [test, dry-run]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Write summary
-        run: |
-          echo '### Test Results' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Suite | Status |' >> $GITHUB_STEP_SUMMARY
-          echo '| ----- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| Matrix | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dry run | ${{ needs.dry-run.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npx semantic-release --ci 2>&1 | tee /tmp/release.log
+        run: |
+          set -o pipefail
+          npx semantic-release --ci 2>&1 | tee /tmp/release.log
 
       - name: Write release summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,23 +88,25 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: npx semantic-release --ci
+        run: npx semantic-release --ci 2>&1 | tee /tmp/release.log
 
-  summary:
-    name: CI summary
-    if: always()
-    needs: [lint, analyze, test, release]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Write summary
+      - name: Write release summary
+        if: always()
         run: |
-          echo '## CI Pipeline Summary' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo '| Gate | Status |' >> $GITHUB_STEP_SUMMARY
-          echo '| ---- | ------ |' >> $GITHUB_STEP_SUMMARY
-          echo "| Lint | ${{ needs.lint.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Analyze | ${{ needs.analyze.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Test | ${{ needs.test.result == 'success' && ':white_check_mark: Pass' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Release | ${{ needs.release.result == 'success' && ':white_check_mark: Pass' || needs.release.result == 'skipped' && ':white_circle: Skipped' || ':x: Fail' }} |" >> $GITHUB_STEP_SUMMARY
+          if [ ! -f /tmp/release.log ]; then
+            echo '### :x: Release Failed' >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          clean=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/release.log)
+          version=$(echo "$clean" | grep -oP 'Published release \K\S+' || true)
+          if [ -n "$version" ]; then
+            echo "### :package: Released v${version}" >> $GITHUB_STEP_SUMMARY
+          elif echo "$clean" | grep -qi 'no relevant changes'; then
+            echo '### :white_circle: No Release' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo 'No relevant changes since the last release.' >> $GITHUB_STEP_SUMMARY
+          else
+            echo '### :x: Release Failed' >> $GITHUB_STEP_SUMMARY
+            echo '' >> $GITHUB_STEP_SUMMARY
+            echo 'Check the job log for details.' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,16 +90,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -o pipefail
-          npx semantic-release --ci 2>&1 | tee /tmp/release.log
+          npx semantic-release --ci 2>&1 | tee "$RUNNER_TEMP/release.log"
 
       - name: Write release summary
         if: always()
         run: |
-          if [ ! -f /tmp/release.log ]; then
+          if [ ! -f "$RUNNER_TEMP/release.log" ]; then
             echo '### :x: Release Failed' >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
-          clean=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/release.log)
+          clean=$(sed 's/\x1b\[[0-9;]*m//g' "$RUNNER_TEMP/release.log")
           version=$(echo "$clean" | grep -oP 'Published release \K\S+' || true)
           if [ -n "$version" ]; then
             echo "### :package: Released v${version}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-main-version.yml
+++ b/.github/workflows/update-main-version.yml
@@ -77,15 +77,3 @@ jobs:
         run: |
           git push origin "${MAJOR_VER}" --force
           echo "::notice title=Main version tagged::Tagged "${TARGET}" with "${MAJOR_VER}""
-
-      - name: Write summary
-        if: ${{ always() }}
-        run: |
-          echo '### Update Main Version' >> $GITHUB_STEP_SUMMARY
-          echo '' >> $GITHUB_STEP_SUMMARY
-          echo "| | |" >> $GITHUB_STEP_SUMMARY
-          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Target** | \`${{ env.TARGET }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Major version** | \`${{ github.event.inputs.version || '(auto-detected)' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Trigger** | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Status** | ${{ job.status == 'success' && ':white_check_mark: Tagged' || ':x: Failed' }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Removes the summary jobs from `_lint.yml`, `_analyze.yml`, `_test.yml`, the CI roll-up summary in `ci.yml`, and the summary step from `update-main-version.yml`.

Replaces them with a single useful summary on the **Semantic release** job that parses `semantic-release` output to report:

- **Released version** — e.g. `### :package: Released v1.2.3`
- **No release** — when no relevant changes are detected
- **Failure** — when semantic-release encounters an error