### PR TITLE
fix(ci): publish GitHub releases from semantic-release

### DIFF
--- a/.github/workflows/_semantic-tag.yml
+++ b/.github/workflows/_semantic-tag.yml
@@ -14,7 +14,6 @@ jobs:
   semantic-tag:
     name: Semantic release
     runs-on: ubuntu-latest
-    # Keep this workflow reusable-only so releases stay gated by ci.yml.
 
     # https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md
     permissions:

--- a/.github/workflows/_semantic-tag.yml
+++ b/.github/workflows/_semantic-tag.yml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+#
+# Reusable semantic release gate: publish tags, changelog updates, and GitHub releases.
+
+name: Semantic tag
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+  workflow_dispatch:
+
+jobs:
+  semantic-tag:
+    name: Semantic release
+    runs-on: ubuntu-latest
+
+    # https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@main
+        with:
+          node-version: 'lts/*'
+
+      - name: Install npm global packages
+        run: >-
+          npm install -g
+          semantic-release
+          @semantic-release/commit-analyzer
+          @semantic-release/exec
+          @semantic-release/git
+          @semantic-release/github
+          @semantic-release/release-notes-generator
+          @semantic-release/changelog
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -o pipefail
+          npx semantic-release --ci 2>&1 | tee "$RUNNER_TEMP/release.log"
+
+      - name: Write release summary
+        if: always()
+        run: |
+          if [ ! -f "$RUNNER_TEMP/release.log" ]; then
+            {
+              echo '### Release failed'
+              echo ''
+              echo 'Check the job log for details.'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          clean=$(sed 's/\x1b\[[0-9;]*m//g' "$RUNNER_TEMP/release.log")
+          version=$(echo "$clean" | grep -oP 'Published release \K\S+' || true)
+
+          if [ -n "$version" ]; then
+            echo "### Released ${version}" >> "$GITHUB_STEP_SUMMARY"
+          elif echo "$clean" | grep -qi 'no relevant changes'; then
+            {
+              echo '### No release'
+              echo ''
+              echo 'No relevant changes were detected since the last release.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo '### Release failed'
+              echo ''
+              echo 'Check the job log for details.'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/_semantic-tag.yml
+++ b/.github/workflows/_semantic-tag.yml
@@ -9,12 +9,12 @@ on:
     secrets:
       GH_TOKEN:
         required: true
-  workflow_dispatch:
 
 jobs:
   semantic-tag:
     name: Semantic release
     runs-on: ubuntu-latest
+    # Keep this workflow reusable-only so releases stay gated by ci.yml.
 
     # https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,63 +55,14 @@ jobs:
     permissions:
       contents: read
 
-  release:
+  semantic-tag:
     name: Semantic release
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: test
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/_semantic-tag.yml
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     permissions:
       contents: write
       issues: write
       pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@main
-        with:
-          node-version: 'lts/*'
-
-      - name: Install semantic-release
-        run: >-
-          npm install -g
-          semantic-release
-          @semantic-release/commit-analyzer
-          @semantic-release/exec
-          @semantic-release/git
-          @semantic-release/github
-          @semantic-release/release-notes-generator
-          @semantic-release/changelog
-
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          set -o pipefail
-          npx semantic-release --ci 2>&1 | tee "$RUNNER_TEMP/release.log"
-
-      - name: Write release summary
-        if: always()
-        run: |
-          if [ ! -f "$RUNNER_TEMP/release.log" ]; then
-            echo '### :x: Release Failed' >> $GITHUB_STEP_SUMMARY
-            exit 0
-          fi
-          clean=$(sed 's/\x1b\[[0-9;]*m//g' "$RUNNER_TEMP/release.log")
-          version=$(echo "$clean" | grep -oP 'Published release \K\S+' || true)
-          if [ -n "$version" ]; then
-            echo "### :package: Released v${version}" >> $GITHUB_STEP_SUMMARY
-          elif echo "$clean" | grep -qi 'no relevant changes'; then
-            echo '### :white_circle: No Release' >> $GITHUB_STEP_SUMMARY
-            echo '' >> $GITHUB_STEP_SUMMARY
-            echo 'No relevant changes since the last release.' >> $GITHUB_STEP_SUMMARY
-          else
-            echo '### :x: Release Failed' >> $GITHUB_STEP_SUMMARY
-            echo '' >> $GITHUB_STEP_SUMMARY
-            echo 'Check the job log for details.' >> $GITHUB_STEP_SUMMARY
-          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@main
         with:
+          fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Setup Node.js
@@ -82,6 +84,7 @@ jobs:
           @semantic-release/commit-analyzer
           @semantic-release/exec
           @semantic-release/git
+          @semantic-release/github
           @semantic-release/release-notes-generator
           @semantic-release/changelog
 

--- a/.releaserc
+++ b/.releaserc
@@ -22,6 +22,7 @@
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
-    ]
+    ],
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- add @semantic-release/github to the semantic-release plugin list
- extract the semantic release job into .github/workflows/_semantic-tag.yml to match the setup-ssis-devops-tools pattern
- update ci.yml to call the reusable semantic release workflow
- align the Write release summary step with the setup-ssis-devops-tools workflow

## Verification
- ran git diff --check
- parsed .releaserc with Node.js
- parsed .github/workflows/ci.yml and .github/workflows/_semantic-tag.yml with Ruby YAML
