### PR TITLE
refactor: always enable follow-symlinks when supported

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -88,7 +88,6 @@ body:
         exclude: ''
         recurse: false
         depth: 0
-        follow-symlinks: false
         encoding: auto
         no-newline: false
         dry-run: false
@@ -143,4 +142,4 @@ body:
     id: additional_context
     attributes:
       label: Additional context
-      description: Include details such as encoding, symlink usage, path patterns, line ending expectations, or platform-specific differences.
+      description: Include details such as encoding, path patterns, line ending expectations, or platform-specific differences.

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -24,9 +24,6 @@ function Expand-TemplateFile
     .PARAMETER Depth
         Specify the depth of recursion. Only valid when Recurse is specified.
 
-    .PARAMETER FollowSymlinks
-        Follow symbolic links when traversing directories.
-
     .PARAMETER Encoding
         Specify the file encoding. Default: auto
 
@@ -89,10 +86,6 @@ function Expand-TemplateFile
         [Parameter(HelpMessage = 'Specify the depth of recursion')]
         [int]
         $Depth,
-
-        [Parameter(HelpMessage = 'Follow symbolic links')]
-        [switch]
-        $FollowSymlinks,
 
         [Parameter(HelpMessage = 'Specify the file encoding')]
         [ValidateSet('auto', 'utf8', 'utf-8', 'utf8NoBOM', 'utf8BOM', 'ascii', 'ansi', 'bigendianunicode', 'bigendianutf32', 'oem', 'unicode', 'utf32', IgnoreCase = $true)]
@@ -784,16 +777,6 @@ function Expand-TemplateFile
         # Check whether Get-ChildItem supports -FollowSymlink (not available on Windows PowerShell 5.1)
         $followSymlinkSupported = (Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')
 
-        if ($FollowSymlinks -and -not $Recurse)
-        {
-            Write-Warning 'The -FollowSymlinks parameter has no effect without -Recurse.'
-        }
-
-        if ($FollowSymlinks -and -not $followSymlinkSupported)
-        {
-            Write-Warning 'The -FollowSymlinks parameter is not supported on this version of PowerShell and will be ignored.'
-        }
-
         # Initialize tracking variables
         $script:fileResults = New-Object System.Collections.Generic.List[PSCustomObject]
         $script:tokensReplaced = 0
@@ -927,7 +910,7 @@ function Expand-TemplateFile
         if (-not [string]::IsNullOrWhiteSpace($Filter)) { $params.Add('Filter', $Filter) }
         if ($Recurse) { $params.Add('Recurse', $true) }
         if ($Depth -gt 0) { $params.Add('Depth', $Depth) }
-        if ($FollowSymlinks -and $followSymlinkSupported) { $params.Add('FollowSymlink', $true) }
+        if ($followSymlinkSupported) { $params.Add('FollowSymlink', $true) }
         if ($Exclude) { $params.Add('Exclude', $Exclude) }
 
         # Get files to process

--- a/README.md
+++ b/README.md
@@ -41,14 +41,15 @@ See [action.yml](action.yml).
 | `recurse`          | Search subdirectories            | boolean | false    | `false`    | `true`        |
 | `depth`            | Recursion depth (`0` = no limit) | number  | false    | `0`        | `2`           |
 | `dry-run`          | Preview without modifying files  | boolean | false    | `false`    | `true`        |
-
-> **Note:** When `recurse` is enabled, symbolic links are followed automatically on PowerShell Core 6+. On Windows PowerShell 5.1, symbolic links are not followed because the underlying `Get-ChildItem -FollowSymlink` parameter is not available.
 | `fail`             | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
 | `fail-on-skipped`  | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
 | `case-insensitive` | Ignore env variable casing       | boolean | false    | `false`    | `true`        |
 | `encoding`         | [File encoding](#file-encoding)  | string  | false    | `auto`     | `unicode`     |
 | `no-newline`       | Skip the final newline           | boolean | false    | `false`    | `true`        |
 | `verbose`          | Enable verbose logging           | boolean | false    | `false`    | `true`        |
+
+> [!Note]
+> When `recurse` is enabled, symbolic links are followed automatically on PowerShell Core 6+. On Windows PowerShell 5.1, symbolic links are not followed because the underlying `Get-ChildItem -FollowSymlink` parameter is not available.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ See [action.yml](action.yml).
 | `exclude`          | Exclude patterns [^3]            | string  | false    | none       | `*dev*.json`  |
 | `recurse`          | Search subdirectories            | boolean | false    | `false`    | `true`        |
 | `depth`            | Recursion depth (`0` = no limit) | number  | false    | `0`        | `2`           |
-| `follow-symlinks`  | Follow symbolic links            | boolean | false    | `false`    | `true`        |
 | `dry-run`          | Preview without modifying files  | boolean | false    | `false`    | `true`        |
 | `fail`             | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
 | `fail-on-skipped`  | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ See [action.yml](action.yml).
 | `recurse`          | Search subdirectories            | boolean | false    | `false`    | `true`        |
 | `depth`            | Recursion depth (`0` = no limit) | number  | false    | `0`        | `2`           |
 | `dry-run`          | Preview without modifying files  | boolean | false    | `false`    | `true`        |
+
+> **Note:** When `recurse` is enabled, symbolic links are followed automatically on PowerShell Core 6+. On Windows PowerShell 5.1, symbolic links are not followed because the underlying `Get-ChildItem -FollowSymlink` parameter is not available.
 | `fail`             | Fail if nothing changes [^4]     | boolean | false    | `false`    | `true`        |
 | `fail-on-skipped`  | Fail if any token is unresolved  | boolean | false    | `false`    | `true`        |
 | `case-insensitive` | Ignore env variable casing       | boolean | false    | `false`    | `true`        |

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -1106,43 +1106,4 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Test Zero'
     }
 
-    It 'Warns when -FollowSymlinks is used without -Recurse' {
-        # Arrange
-        $testFile = Join-Path -Path $testDir -ChildPath 'symlinks-no-recurse.txt'
-        Write-Utf8Content -Path $testFile -Value 'Test content' -NoNewline
-
-        # Act
-        $null = Expand-TemplateFile -Path $testFile -Style 'mustache' -FollowSymlinks -Encoding 'utf8NoBOM' -NoNewline -WarningVariable warnings
-
-        # Assert
-        $warnings.Count | Should -BeGreaterThan 0
-        ($warnings | Out-String) | Should -Match 'FollowSymlinks'
-    }
-
-    It 'Does not warn about -FollowSymlinks when -Recurse is also specified' -Skip:(-not (Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {
-        # Arrange
-        $symlinkDir = Join-Path -Path $testDir -ChildPath 'symlinks-with-recurse'
-        New-Item -Path $symlinkDir -ItemType Directory -Force | Out-Null
-        $testFile = Join-Path -Path $symlinkDir -ChildPath 'test.txt'
-        Write-Utf8Content -Path $testFile -Value 'Test content' -NoNewline
-
-        # Act
-        $null = Expand-TemplateFile -Path $symlinkDir -Style 'mustache' -FollowSymlinks -Recurse -Encoding 'utf8NoBOM' -NoNewline -WarningVariable warnings
-
-        # Assert
-        $warnings.Count | Should -Be 0
-    }
-
-    It 'Warns when -FollowSymlinks is used on a PowerShell version that does not support it' -Skip:((Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {
-        # Arrange
-        $testFile = Join-Path -Path $testDir -ChildPath 'symlinks-unsupported.txt'
-        Write-Utf8Content -Path $testFile -Value 'Test content' -NoNewline
-
-        # Act
-        $null = Expand-TemplateFile -Path $testFile -Style 'mustache' -FollowSymlinks -Recurse -Encoding 'utf8NoBOM' -NoNewline -WarningVariable warnings
-
-        # Assert
-        $warnings.Count | Should -BeGreaterThan 0
-        ($warnings | Out-String) | Should -Match 'not supported'
-    }
 }

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -1106,4 +1106,42 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Test Zero'
     }
 
+    It 'Follows symlinks by default during recursive traversal when supported' -Skip:(-not (Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {
+        # Arrange
+        $symlinkDir = Join-Path -Path $testDir -ChildPath 'symlink-auto'
+        New-Item -Path $symlinkDir -ItemType Directory -Force | Out-Null
+
+        $targetDir = Join-Path -Path $testDir -ChildPath 'symlink-target'
+        New-Item -Path $targetDir -ItemType Directory -Force | Out-Null
+
+        $targetFile = Join-Path -Path $targetDir -ChildPath 'linked.txt'
+        $env:SYMLINK_VAR = 'Resolved'
+        Write-Utf8Content -Path $targetFile -Value '{{SYMLINK_VAR}}' -NoNewline
+
+        $linkPath = Join-Path -Path $symlinkDir -ChildPath 'link'
+        New-Item -ItemType SymbolicLink -Path $linkPath -Target $targetDir -Force | Out-Null
+
+        # Act
+        $result = @(Expand-TemplateFile -Path $symlinkDir -Style 'mustache' -Recurse -Encoding 'utf8NoBOM' -NoNewline)
+
+        # Assert - the file behind the symlink should be processed
+        $result.Count | Should -BeGreaterThan 0
+        $content = Get-Content -Path $targetFile -Raw
+        $content | Should -Be 'Resolved'
+    }
+
+    It 'Does not fail on versions that lack -FollowSymlink support' -Skip:((Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {
+        # Arrange
+        $testFile = Join-Path -Path $testDir -ChildPath 'no-followsymlink-support.txt'
+        $env:NOSYM = 'ok'
+        Write-Utf8Content -Path $testFile -Value '{{NOSYM}}' -NoNewline
+
+        # Act - should succeed without errors even though FollowSymlink is not available
+        { Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline } | Should -Not -Throw
+
+        # Assert
+        $content = Get-Content -Path $testFile -Raw
+        $content | Should -Be 'ok'
+    }
+
 }

--- a/action.ps1
+++ b/action.ps1
@@ -32,10 +32,6 @@
     .PARAMETER Depth
         A string integer value that sets the recursion depth when Recurse is true.
 
-    .PARAMETER FollowSymlinks
-        A string boolean value that controls whether symbolic links are followed
-        while traversing directories.
-
     .PARAMETER Encoding
         The file encoding passed to Expand-TemplateFile.ps1 for read and write
         operations.
@@ -129,9 +125,6 @@ param(
     $Depth = '0',
 
     [string]
-    $FollowSymlinks = 'false',
-
-    [string]
     $Encoding = 'auto',
 
     [string]
@@ -207,7 +200,6 @@ $params = @{
     Style = $Style
     Recurse = [System.Convert]::ToBoolean($Recurse)
     Depth = [System.Convert]::ToInt32($Depth)
-    FollowSymlinks = [System.Convert]::ToBoolean($FollowSymlinks)
     Encoding = $Encoding
     NoNewline = [System.Convert]::ToBoolean($NoNewline)
     Verbose = [System.Convert]::ToBoolean($VerboseInput)

--- a/action.yml
+++ b/action.yml
@@ -54,13 +54,6 @@ inputs:
     required: false
     default: '0'
 
-  follow-symlinks:
-    description: >-
-      Whether to follow symbolic links.
-      Defaults to `false`.
-    required: false
-    default: 'false'
-
   encoding:
     description: >-
       File encoding to use when reading and writing files.
@@ -159,7 +152,6 @@ runs:
           -ExcludeInput $excludeInput `
           -Recurse '${{ inputs.recurse }}' `
           -Depth '${{ inputs.depth }}' `
-          -FollowSymlinks '${{ inputs.follow-symlinks }}' `
           -Encoding $encodingInput `
           -NoNewline '${{ inputs.no-newline }}' `
           -DryRun '${{ inputs.dry-run }}' `


### PR DESCRIPTION
Remove the `follow-symlinks` action input and `-FollowSymlinks` parameter. Symbolic links are now always followed during directory traversal when the underlying PowerShell version supports it (Core 6+).

### Changes

- Removed `follow-symlinks` input from `action.yml`
- Removed `-FollowSymlinks` parameter from `action.ps1` and `Expand-TemplateFile.ps1`
- `Get-ChildItem -FollowSymlink` is now always passed when the PowerShell version supports it
- Removed related tests, documentation, and bug report template references