### PR TITLE
feat: issue template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,8 @@ body:
 
         Include a minimal reproduction when possible. This project supports:
         - Windows PowerShell 5.1 on Windows runners
-        - PowerShell Core on Linux and macOS runners
-        - Token styles: mustache, handlebars, brackets, double-hashes, envsubst, make
+        - PowerShell Core on Windows, Linux, and macOS runners
+        - Token styles: mustache, handlebars, brackets, hashes, underscores, envsubst, make
 
   - type: checkboxes
     id: checks
@@ -69,7 +69,8 @@ body:
         - mustache
         - handlebars
         - brackets
-        - double-hashes
+        - hashes
+        - underscores
         - envsubst
         - make
         - Multiple
@@ -92,6 +93,8 @@ body:
         no-newline: false
         dry-run: false
         fail: false
+        fail-on-skipped: false
+        case-insensitive: false
         verbose: true
       render: yaml
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
 
         Keep compatibility in mind:
         - Windows PowerShell 5.1 must remain supported
-        - PowerShell Core on Linux and macOS must remain supported
+        - PowerShell Core on Windows, Linux, and macOS must remain supported
         - Changes usually need tests and documentation updates
 
   - type: checkboxes
@@ -71,6 +71,7 @@ body:
       description: Mark the environments or concerns that apply.
       options:
         - label: This needs to work on Windows PowerShell 5.1.
+        - label: This needs to work on PowerShell Core on Windows.
         - label: This needs to work on PowerShell Core on Linux.
         - label: This needs to work on PowerShell Core on macOS.
         - label: This may affect existing token styles or matching rules.


### PR DESCRIPTION
Update GitHub issue template forms to reflect current action capabilities:

- Add PowerShell Core on Windows as a supported runtime (bug report and feature request)
- Rename `double-hashes` to `hashes` to match the actual `style` input value
- Add missing `underscores` token style to the supported list and dropdown
- Add `fail-on-skipped` and `case-insensitive` to the bug report inputs placeholder
- Add "PowerShell Core on Windows" compatibility checkbox to feature request