### PR TITLE
fix: improve robustness and correctness

### DIFF
--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -766,59 +766,6 @@ function Expand-TemplateFile
             }
         }
 
-        function Test-IsLikelyBinaryFile
-        {
-            param(
-                [string]
-                $File
-            )
-
-            $stream = $null
-
-            try
-            {
-                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Open), ([System.IO.FileAccess]::Read), ([System.IO.FileShare]::ReadWrite)
-                $bufferSize = [Math]::Min(8192, $stream.Length)
-
-                if ($bufferSize -eq 0)
-                {
-                    return $false
-                }
-
-                $buffer = New-Object byte[] $bufferSize
-                $bytesRead = $stream.Read($buffer, 0, $bufferSize)
-
-                # UTF-16 text files contain frequent null bytes between characters;
-                # check for UTF-16 encoding first so they are not treated as binary.
-                if (Test-IsLikelyUtf16 -Bytes $buffer -Count $bytesRead -BigEndian $false)
-                {
-                    return $false
-                }
-
-                if (Test-IsLikelyUtf16 -Bytes $buffer -Count $bytesRead -BigEndian $true)
-                {
-                    return $false
-                }
-
-                for ($index = 0; $index -lt $bytesRead; $index++)
-                {
-                    if ($buffer[$index] -eq 0)
-                    {
-                        return $true
-                    }
-                }
-
-                return $false
-            }
-            finally
-            {
-                if ($null -ne $stream)
-                {
-                    $stream.Dispose()
-                }
-            }
-        }
-
         Register-CodePagesEncodingProvider
 
         # Validate that -Depth is only used with -Recurse
@@ -883,13 +830,6 @@ function Expand-TemplateFile
 
             try
             {
-                # Skip binary files to avoid corruption; inside try so access errors are handled consistently
-                if (Test-IsLikelyBinaryFile -File $File)
-                {
-                    Write-Verbose "[$File] Skipped binary file"
-                    return
-                }
-
                 $fileState = Read-FileContent -File $File -RequestedEncodingName $RequestedEncodingName
                 $encodingInfo = $fileState.EncodingInfo
                 $content = $fileState.Content

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -893,11 +893,15 @@ function Expand-TemplateFile
             }
             catch
             {
+                $tokensReplaced = $script:tokensInFile
+                $tokensSkipped = $script:skippedInFile
+                $wouldModify = ($tokensReplaced -gt 0)
+
                 $script:fileResults.Add([PSCustomObject]@{
                     FilePath = $File
-                    TokensReplaced = 0
-                    TokensSkipped = 0
-                    WouldModify = $false
+                    TokensReplaced = $tokensReplaced
+                    TokensSkipped = $tokensSkipped
+                    WouldModify = $wouldModify
                     Modified = $false
                     Error = $_.Exception.Message
                 })

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -735,13 +735,13 @@ function Expand-TemplateFile
                     {
                         $newlineSequence = Get-PreferredNewlineSequence -Content $OriginalContent
 
-                        if ([string]::IsNullOrEmpty($NewlineSequence))
+                        if ([string]::IsNullOrEmpty($newlineSequence))
                         {
                             $finalContent += [Environment]::NewLine
                         }
                         else
                         {
-                            $finalContent += $NewlineSequence
+                            $finalContent += $newlineSequence
                         }
                     }
                 }
@@ -762,6 +762,47 @@ function Expand-TemplateFile
                 elseif ($null -ne $fileStream)
                 {
                     $fileStream.Dispose()
+                }
+            }
+        }
+
+        function Test-IsLikelyBinaryFile
+        {
+            param(
+                [string]
+                $File
+            )
+
+            $stream = $null
+
+            try
+            {
+                $stream = New-Object -TypeName System.IO.FileStream -ArgumentList $File, ([System.IO.FileMode]::Open), ([System.IO.FileAccess]::Read), ([System.IO.FileShare]::ReadWrite)
+                $bufferSize = [Math]::Min(8192, $stream.Length)
+
+                if ($bufferSize -eq 0)
+                {
+                    return $false
+                }
+
+                $buffer = New-Object byte[] $bufferSize
+                $bytesRead = $stream.Read($buffer, 0, $bufferSize)
+
+                for ($index = 0; $index -lt $bytesRead; $index++)
+                {
+                    if ($buffer[$index] -eq 0)
+                    {
+                        return $true
+                    }
+                }
+
+                return $false
+            }
+            finally
+            {
+                if ($null -ne $stream)
+                {
+                    $stream.Dispose()
                 }
             }
         }
@@ -824,6 +865,13 @@ function Expand-TemplateFile
         # Function to replace tokens in a file
         function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string, string]] $EnvironmentVars, [string] $RequestedEncodingName, [bool] $NoNewline)
         {
+            # Skip binary files to avoid corruption
+            if (Test-IsLikelyBinaryFile -File $File)
+            {
+                Write-Verbose "[$File] Skipped binary file"
+                return
+            }
+
             # Use script-scoped variables for per-file counters so they work inside scriptblocks
             $script:tokensInFile = 0
             $script:skippedInFile = 0
@@ -849,7 +897,7 @@ function Expand-TemplateFile
                         }
 
                         $replacement = $EnvironmentVars[$varName]
-                        if ([string]::IsNullOrWhiteSpace($replacement))
+                        if ([string]::IsNullOrEmpty($replacement))
                         {
                             Write-Warning "[$File] Environment variable '$varName' exists but has empty value - token will not be replaced"
                             $script:tokensSkipped++
@@ -893,6 +941,15 @@ function Expand-TemplateFile
             }
             catch
             {
+                $script:fileResults.Add([PSCustomObject]@{
+                    FilePath = $File
+                    TokensReplaced = 0
+                    TokensSkipped = 0
+                    WouldModify = $false
+                    Modified = $false
+                    Error = $_.Exception.Message
+                })
+
                 Write-Error "Failed to process file ${File}: $_"
             }
         }

--- a/Expand-TemplateFile.ps1
+++ b/Expand-TemplateFile.ps1
@@ -788,6 +788,18 @@ function Expand-TemplateFile
                 $buffer = New-Object byte[] $bufferSize
                 $bytesRead = $stream.Read($buffer, 0, $bufferSize)
 
+                # UTF-16 text files contain frequent null bytes between characters;
+                # check for UTF-16 encoding first so they are not treated as binary.
+                if (Test-IsLikelyUtf16 -Bytes $buffer -Count $bytesRead -BigEndian $false)
+                {
+                    return $false
+                }
+
+                if (Test-IsLikelyUtf16 -Bytes $buffer -Count $bytesRead -BigEndian $true)
+                {
+                    return $false
+                }
+
                 for ($index = 0; $index -lt $bytesRead; $index++)
                 {
                     if ($buffer[$index] -eq 0)
@@ -865,19 +877,19 @@ function Expand-TemplateFile
         # Function to replace tokens in a file
         function ReplaceTokens([string] $File, [System.Text.RegularExpressions.Regex] $TokenRegex, [System.Collections.Generic.Dictionary[string, string]] $EnvironmentVars, [string] $RequestedEncodingName, [bool] $NoNewline)
         {
-            # Skip binary files to avoid corruption
-            if (Test-IsLikelyBinaryFile -File $File)
-            {
-                Write-Verbose "[$File] Skipped binary file"
-                return
-            }
-
             # Use script-scoped variables for per-file counters so they work inside scriptblocks
             $script:tokensInFile = 0
             $script:skippedInFile = 0
 
             try
             {
+                # Skip binary files to avoid corruption; inside try so access errors are handled consistently
+                if (Test-IsLikelyBinaryFile -File $File)
+                {
+                    Write-Verbose "[$File] Skipped binary file"
+                    return
+                }
+
                 $fileState = Read-FileContent -File $File -RequestedEncodingName $RequestedEncodingName
                 $encodingInfo = $fileState.EncodingInfo
                 $content = $fileState.Content
@@ -950,7 +962,7 @@ function Expand-TemplateFile
                     Error = $_.Exception.Message
                 })
 
-                Write-Error "Failed to process file ${File}: $_"
+                Write-Error -ErrorRecord $_
             }
         }
     }

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -139,7 +139,7 @@ Describe 'Expand-TemplateFile Function' {
             'NAME', '_NAME', 'ID', 'VALID_NAME', '_TEST_VAR', 'SPECIAL',
             'ENV_VAR', '123VAR', 'BRACKET_VAR', 'HASH_VAR', 'MAKE_VAR', 'MAKE', 'MAKE-VAR',
             'VAR', 'VAR2', 'VAR3', 'USER', 'HOSTNAME', 'TESTVAR',
-            '1INVALID'
+            '1INVALID', 'SYMLINK_VAR', 'NOSYM'
         )
     }
 
@@ -1104,6 +1104,58 @@ Describe 'Expand-TemplateFile Function' {
         # Assert
         $content = Get-Content -Path $testFile -Raw
         $content | Should -Be 'Test Zero'
+    }
+
+    It 'Skips binary files without corrupting them' {
+        # Arrange
+        $binaryFile = Join-Path -Path $testDir -ChildPath 'binary-file.bin'
+        $binaryContent = [byte[]](0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00)
+        [System.IO.File]::WriteAllBytes($binaryFile, $binaryContent)
+        $originalHash = (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash
+
+        $env:NAME = 'ShouldNotAppear'
+
+        # Act
+        $result = Expand-TemplateFile -Path $binaryFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
+
+        # Assert - file must remain untouched
+        (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash | Should -Be $originalHash
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'Skips binary files in a directory without affecting text files' {
+        # Arrange
+        $mixedBinaryDir = Join-Path -Path $testDir -ChildPath 'mixed-binary-dir'
+        New-Item -Path $mixedBinaryDir -ItemType Directory -Force | Out-Null
+
+        $textFile = Join-Path -Path $mixedBinaryDir -ChildPath 'template.txt'
+        Write-Utf8Content -Path $textFile -Value 'Hello, {{NAME}}!' -NoNewline
+
+        $binaryFile = Join-Path -Path $mixedBinaryDir -ChildPath 'image.bin'
+        [System.IO.File]::WriteAllBytes($binaryFile, [byte[]](0x00, 0x01, 0x02, 0x03))
+        $binaryHash = (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash
+
+        $env:NAME = 'World'
+
+        # Act
+        $result = Expand-TemplateFile -Path $mixedBinaryDir -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
+
+        # Assert
+        (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash | Should -Be $binaryHash
+        (Get-Content -Path $textFile -Raw) | Should -Be 'Hello, World!'
+        $result.Count | Should -Be 1
+        $result[0].FilePath | Should -Be $textFile
+    }
+
+    It 'Records an error result when a file cannot be read' {
+        # Arrange
+        $missingFile = Join-Path -Path $testDir -ChildPath 'does-not-exist.txt'
+
+        # Act
+        $result = Expand-TemplateFile -Path $missingFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline -ErrorAction SilentlyContinue
+
+        # Assert - no result entries are produced for missing files (Get-ChildItem finds nothing)
+        $result | Should -BeNullOrEmpty
     }
 
     It 'Follows symlinks by default during recursive traversal when supported' -Skip:(-not (Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -1109,47 +1109,6 @@ Describe 'Expand-TemplateFile Function' {
         $content | Should -Be 'Test Zero'
     }
 
-    It 'Skips binary files without corrupting them' {
-        # Arrange
-        $binaryFile = Join-Path -Path $testDir -ChildPath 'binary-file.bin'
-        $binaryContent = [byte[]](0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00)
-        [System.IO.File]::WriteAllBytes($binaryFile, $binaryContent)
-        $originalHash = (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash
-
-        $env:NAME = 'ShouldNotAppear'
-
-        # Act
-        $result = Expand-TemplateFile -Path $binaryFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
-
-        # Assert - file must remain untouched
-        (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash | Should -Be $originalHash
-        $result | Should -BeNullOrEmpty
-    }
-
-    It 'Skips binary files in a directory without affecting text files' {
-        # Arrange
-        $mixedBinaryDir = Join-Path -Path $testDir -ChildPath 'mixed-binary-dir'
-        New-Item -Path $mixedBinaryDir -ItemType Directory -Force | Out-Null
-
-        $textFile = Join-Path -Path $mixedBinaryDir -ChildPath 'template.txt'
-        Write-Utf8Content -Path $textFile -Value 'Hello, {{NAME}}!' -NoNewline
-
-        $binaryFile = Join-Path -Path $mixedBinaryDir -ChildPath 'image.bin'
-        [System.IO.File]::WriteAllBytes($binaryFile, [byte[]](0x00, 0x01, 0x02, 0x03))
-        $binaryHash = (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash
-
-        $env:NAME = 'World'
-
-        # Act
-        $result = Expand-TemplateFile -Path $mixedBinaryDir -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
-
-        # Assert
-        (Get-FileHash -Path $binaryFile -Algorithm SHA256).Hash | Should -Be $binaryHash
-        (Get-Content -Path $textFile -Raw) | Should -Be 'Hello, World!'
-        $result.Count | Should -Be 1
-        $result[0].FilePath | Should -Be $textFile
-    }
-
     It 'Produces no results when the path does not exist' {
         # Arrange - the target path does not exist, so nothing is processed
         $missingFile = Join-Path -Path $testDir -ChildPath 'does-not-exist.txt'

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -139,7 +139,7 @@ Describe 'Expand-TemplateFile Function' {
             'NAME', '_NAME', 'ID', 'VALID_NAME', '_TEST_VAR', 'SPECIAL',
             'ENV_VAR', '123VAR', 'BRACKET_VAR', 'HASH_VAR', 'MAKE_VAR', 'MAKE', 'MAKE-VAR',
             'VAR', 'VAR2', 'VAR3', 'USER', 'HOSTNAME', 'TESTVAR',
-            '1INVALID', 'SYMLINK_VAR', 'NOSYM'
+            '1INVALID', 'SYMLINK_VAR', 'NOSYM', 'LOCKED_VAR'
         )
     }
 
@@ -302,9 +302,12 @@ Describe 'Expand-TemplateFile Function' {
         $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8' -NoNewline -ErrorAction SilentlyContinue
         $content = [System.IO.File]::ReadAllText($testFile, $unicodeEncoding)
 
-        # Assert
+        # Assert - explicit utf8 does not follow the detected UTF-16 encoding; the token
+        # pattern does not match the garbled UTF-8-over-UTF-16 content, so the file is
+        # returned in results but has no tokens replaced and is not written.
         $content | Should -Be 'Hello, {{NAME}}!'
-        $result | Should -BeNullOrEmpty
+        $result | Should -Not -BeNullOrEmpty
+        $result.Modified | Should -Be $false
         (Test-FileStartsWithPrefix -Path $testFile -Prefix ([byte[]](0xFF, 0xFE))) | Should -Be $true
     }
 
@@ -1147,15 +1150,51 @@ Describe 'Expand-TemplateFile Function' {
         $result[0].FilePath | Should -Be $textFile
     }
 
-    It 'Records an error result when a file cannot be read' {
-        # Arrange
+    It 'Produces no results when the path does not exist' {
+        # Arrange - the target path does not exist, so nothing is processed
         $missingFile = Join-Path -Path $testDir -ChildPath 'does-not-exist.txt'
 
         # Act
         $result = Expand-TemplateFile -Path $missingFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline -ErrorAction SilentlyContinue
 
-        # Assert - no result entries are produced for missing files (Get-ChildItem finds nothing)
+        # Assert - no result entries are produced for missing paths
         $result | Should -BeNullOrEmpty
+    }
+
+    It 'Records an error result when reading an existing file fails' -Skip:(-not $script:isWindowsPlatform) {
+        # Arrange - create a file then hold it open with an exclusive lock (Windows only)
+        $lockedFile = Join-Path -Path $testDir -ChildPath 'locked-file.txt'
+        $env:LOCKED_VAR = 'value'
+        Write-Utf8Content -Path $lockedFile -Value '{{LOCKED_VAR}}' -NoNewline
+
+        $fileStream = $null
+        try
+        {
+            $fileStream = [System.IO.File]::Open(
+                $lockedFile,
+                [System.IO.FileMode]::Open,
+                [System.IO.FileAccess]::Read,
+                [System.IO.FileShare]::None
+            )
+
+            # Act - with SilentlyContinue, a result object with an Error field should be emitted
+            $result = @(Expand-TemplateFile -Path $lockedFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline -ErrorAction SilentlyContinue)
+
+            # Assert - one result with an Error for the locked file
+            $result.Count | Should -Be 1
+            $result[0].FilePath | Should -Be $lockedFile
+            $result[0].Error | Should -Not -BeNullOrEmpty
+
+            # Assert - with -ErrorAction Stop, the read failure should surface as a terminating error
+            { Expand-TemplateFile -Path $lockedFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline -ErrorAction Stop } | Should -Throw
+        }
+        finally
+        {
+            if ($null -ne $fileStream)
+            {
+                $fileStream.Dispose()
+            }
+        }
     }
 
     It 'Follows symlinks by default during recursive traversal when supported' -Skip:(-not (Get-Command Get-ChildItem).Parameters.ContainsKey('FollowSymlink')) {

--- a/Tests/Expand-TemplateFile.Tests.ps1
+++ b/Tests/Expand-TemplateFile.Tests.ps1
@@ -139,7 +139,7 @@ Describe 'Expand-TemplateFile Function' {
             'NAME', '_NAME', 'ID', 'VALID_NAME', '_TEST_VAR', 'SPECIAL',
             'ENV_VAR', '123VAR', 'BRACKET_VAR', 'HASH_VAR', 'MAKE_VAR', 'MAKE', 'MAKE-VAR',
             'VAR', 'VAR2', 'VAR3', 'USER', 'HOSTNAME', 'TESTVAR',
-            '1INVALID', 'SYMLINK_VAR', 'NOSYM', 'LOCKED_VAR'
+            '1INVALID', 'SYMLINK_VAR', 'NOSYM', 'LOCKED_VAR', 'WHITESPACE_VAR'
         )
     }
 
@@ -205,6 +205,25 @@ Describe 'Expand-TemplateFile Function' {
 
         # Assert
         $result | Should -Be 'Your ID: {{ID}}' # Should remain unchanged with a warning
+    }
+
+    It 'Replaces a token with a whitespace-only environment variable value' {
+        # Arrange - a value of ' ' is not empty, so IsNullOrEmpty returns false and the
+        # token should be replaced (not skipped) with the literal whitespace characters.
+        $testFile = Join-Path -Path $testDir -ChildPath 'whitespace-only-env-var.txt'
+        Write-Utf8Content -Path $testFile -Value 'prefix {{WHITESPACE_VAR}} suffix' -NoNewline
+
+        $env:WHITESPACE_VAR = ' '
+
+        # Act
+        $result = Expand-TemplateFile -Path $testFile -Style 'mustache' -Encoding 'utf8NoBOM' -NoNewline
+        $content = Get-Content -Path $testFile -Raw
+
+        # Assert
+        $content | Should -Be 'prefix   suffix'
+        $result[0].TokensReplaced | Should -Be 1
+        $result[0].TokensSkipped | Should -Be 0
+        $result[0].Modified | Should -Be $true
     }
 
     It 'Applies correct encoding options' {

--- a/action.ps1
+++ b/action.ps1
@@ -234,7 +234,7 @@ try
 }
 catch
 {
-    $escapedMessage = $_.Exception.Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
+    $escapedMessage = $_.Exception.Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
     Write-Output ('::error title=Failed::{0}' -f $escapedMessage)
     exit 1
 }

--- a/action.ps1
+++ b/action.ps1
@@ -234,7 +234,7 @@ try
 }
 catch
 {
-    $escapedMessage = $_.Exception.Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+    $escapedMessage = $_.Exception.Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
     Write-Output ('::error title=Failed::{0}' -f $escapedMessage)
     exit 1
 }


### PR DESCRIPTION
## Changes

- Use `IsNullOrEmpty` instead of `IsNullOrWhiteSpace` for env var value checks, allowing intentional whitespace-only replacements
- Remove binary file detection entirely — callers are responsible for specifying which files to process
- Re-throw file processing errors so callers using `-ErrorAction Stop` can catch failures
- Preserve original exception type, stack trace, and error category with `Write-Error -ErrorRecord $_`
- Fix variable casing inconsistency in `Write-FileContent`
- Fix colon/comma escaping in GitHub Actions error annotations — only `%`, `\r`, `\n` need escaping in the message segment
- Fix missing env var cleanup in tests for `SYMLINK_VAR` and `NOSYM` variables
- Add locked-file test (Windows-only) to exercise the error-handling path